### PR TITLE
tailwindRotation should emit "transform" class

### DIFF
--- a/__tests__/tailwind/builderImpl/tailwindBlend.test.ts
+++ b/__tests__/tailwind/builderImpl/tailwindBlend.test.ts
@@ -43,21 +43,21 @@ describe("Tailwind Blend", () => {
     expect(tailwindRotation(node)).toEqual("");
 
     node.rotation = 45;
-    expect(tailwindRotation(node)).toEqual("rotate-45 ");
+    expect(tailwindRotation(node)).toEqual("transform rotate-45 ");
 
     node.rotation = 90;
-    expect(tailwindRotation(node)).toEqual("rotate-90 ");
+    expect(tailwindRotation(node)).toEqual("transform rotate-90 ");
 
     node.rotation = 180;
-    expect(tailwindRotation(node)).toEqual("rotate-180 ");
+    expect(tailwindRotation(node)).toEqual("transform rotate-180 ");
 
     node.rotation = -45;
-    expect(tailwindRotation(node)).toEqual("-rotate-45 ");
+    expect(tailwindRotation(node)).toEqual("transform -rotate-45 ");
 
     node.rotation = -90;
-    expect(tailwindRotation(node)).toEqual("-rotate-90 ");
+    expect(tailwindRotation(node)).toEqual("transform -rotate-90 ");
 
     node.rotation = -180;
-    expect(tailwindRotation(node)).toEqual("-rotate-180 ");
+    expect(tailwindRotation(node)).toEqual("transform -rotate-180 ");
   });
 });

--- a/src/tailwind/builderImpl/tailwindBlend.ts
+++ b/src/tailwind/builderImpl/tailwindBlend.ts
@@ -66,7 +66,7 @@ export const tailwindRotation = (node: AltLayoutMixin): string => {
       nearest = -nearest;
     }
 
-    return `${minusIfNegative}rotate-${nearest} `;
+    return `transform ${minusIfNegative}rotate-${nearest} `;
   }
   return "";
 };


### PR DESCRIPTION
Tailwind's rotate class doesn't have effect unless transform class is also present. 
https://tailwindcss.com/docs/rotate#usage

Since you don't seem to use any other Tailwind transforms, I've crudely added the class right into tailwindRotation.