### PR TITLE
Crude support for images in Tailwind

### DIFF
--- a/src/tailwind/tailwindMain.ts
+++ b/src/tailwind/tailwindMain.ts
@@ -11,6 +11,7 @@ import { pxToLayoutSize } from "./conversionTables";
 import { tailwindVector } from "./vector";
 import { TailwindTextBuilder } from "./tailwindTextBuilder";
 import { TailwindDefaultBuilder } from "./tailwindDefaultBuilder";
+import { retrieveTopFill } from "../common/retrieveFill";
 
 let parentId = "";
 let showLayerName = false;
@@ -211,6 +212,12 @@ export const tailwindContainer = (
 
   if (builder.attributes || additionalAttr) {
     const build = builder.build(additionalAttr);
+
+    // image fill and no children -- let's emit an <img />
+    if (retrieveTopFill(node.fills)?.type === "IMAGE" && !children) {
+      const placeholder = `https://via.placeholder.com/${node.width}x${node.height}`;
+      return `\n<img${build} src="${placeholder}" />`;
+    }
 
     if (children) {
       return `\n<div${build}>${indentString(children)}\n</div>`;


### PR DESCRIPTION
Currently the images are exported as divs with no indication whatsoever that they are images — a bit disorienting, the user has to play detective to figure out where to put their assets.

This is my crude fix: treat images as a special case, emit an image tag with a placeholder of the right size. The result looks pretty helpful:
<img width="1072" alt="Снимок экрана 2021-02-16 в 22 38 18" src="https://user-images.githubusercontent.com/1292290/108113483-a4679300-70a8-11eb-9f99-aba61b69a716.png">