### PR TITLE
fix: prevents `div` elements from being self-closing tags

### DIFF
--- a/src/html/htmlMain.ts
+++ b/src/html/htmlMain.ts
@@ -333,7 +333,7 @@ const addSpacingIfNeeded = (
       const style = new HtmlDefaultBuilder(node, false, isJsx).build(
         formatWithJSX(wh, isJsx, node.parent.itemSpacing)
       );
-      return isJsx ? `\n<div${style}/>` : `\n<div ${style}"></div>`;
+      return isJsx ? `\n<div${style}/>` : `\n<div${style}></div>`;
     }
   }
   return "";

--- a/src/html/htmlMain.ts
+++ b/src/html/htmlMain.ts
@@ -16,6 +16,8 @@ let parentId = "";
 
 let showLayerName = false;
 
+const selfClosingTags = ["img"];
+
 export const htmlMain = (
   sceneNode: Array<AltSceneNode>,
   parentIdSrc: string = "",
@@ -218,8 +220,10 @@ export const htmlContainer = (
 
     if (children) {
       return `\n<${tag}${build}${src}>${indentString(children)}\n</${tag}>`;
+    } else if (selfClosingTags.includes(tag) || isJsx) {
+      return `\n<${tag}${build}${src} />`;
     } else {
-      return `\n<${tag}${build}${src}/>`;
+      return `\n<${tag}${build}${src}></${tag}>`;
     }
   }
 
@@ -329,7 +333,7 @@ const addSpacingIfNeeded = (
       const style = new HtmlDefaultBuilder(node, false, isJsx).build(
         formatWithJSX(wh, isJsx, node.parent.itemSpacing)
       );
-      return `\n<div${style}/>`;
+      return isJsx ? `\n<div${style}/>` : `\n<div ${style}"></div>`;
     }
   }
   return "";

--- a/src/tailwind/tailwindMain.ts
+++ b/src/tailwind/tailwindMain.ts
@@ -16,6 +16,8 @@ import { retrieveTopFill } from "../common/retrieveFill";
 let parentId = "";
 let showLayerName = false;
 
+const selfClosingTags = ["img"];
+
 export const tailwindMain = (
   sceneNode: Array<AltSceneNode>,
   parentIdSrc: string = "",
@@ -223,8 +225,10 @@ export const tailwindContainer = (
 
     if (children) {
       return `\n<${tag}${build}${src}>${indentString(children)}\n</${tag}>`;
+    } else if (selfClosingTags.includes(tag) || isJsx) {
+      return `\n<${tag}${build}${src} />`;
     } else {
-      return `\n<${tag}${build}${src}/>`;
+      return `\n<${tag}${build}${src}></${tag}>`;
     }
   }
 


### PR DESCRIPTION
When outputting in Tailwind and HTML without JSX, div elements representing
space in auto-layout are self-closing. This will incorrectly place sibling
HTML elements as children of the self-closing div in the Chrome browser.

Fixes https://github.com/bernaferrari/FigmaToCode/issues/31