### PR TITLE
fix: do not set gap if space is evenly distributed

### DIFF
--- a/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
+++ b/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
@@ -30,7 +30,9 @@ const getAlignItems = (node: inferredAutoLayoutResult): string => {
 };
 
 const getGap = (node: inferredAutoLayoutResult): string | number =>
-  node.itemSpacing > 0 ? node.itemSpacing : "";
+  node.itemSpacing > 0 && node.primaryAxisAlignItems !== "SPACE_BETWEEN"
+    ? node.itemSpacing
+    : "";
 
 const getFlex = (
   node: SceneNode,

--- a/packages/backend/src/tailwind/builderImpl/tailwindAutoLayout.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindAutoLayout.ts
@@ -30,7 +30,9 @@ const getAlignItems = (node: inferredAutoLayoutResult): string => {
 };
 
 const getGap = (node: inferredAutoLayoutResult): string =>
-  node.itemSpacing > 0 ? `gap-${pxToLayoutSize(node.itemSpacing)}` : "";
+  node.itemSpacing > 0 && node.primaryAxisAlignItems !== "SPACE_BETWEEN"
+    ? `gap-${pxToLayoutSize(node.itemSpacing)}`
+    : "";
 
 const getFlex = (
   node: SceneNode,


### PR DESCRIPTION
Hello! Excellent work on this project. I noticed a small bug with the auto layout generation that this should fix.

If an auto layout parent is set to Auto item spacing and it previously had a numerical value, Figma will keep the unused numerical value stored on the node. 

This causes both justify-content: space-between and gap: _n_ px to be set in the generated html. If the gap is larger than the  available space, then the html will render inaccurately compared to the design. I think these 2 properties should be mutually exclusive.

As an example see this simple Figma design with 2 rows of 3 equally sized squares. The top row has an item spacing of 25px, while the second row initially had an item spacing of 50px but it is now Auto:

![Screenshot 2023-08-17 at 11 58 59](https://github.com/bernaferrari/FigmaToCode/assets/69250922/f06a01a9-240d-4501-9f13-a13c4ebd4f3c)

This generates the html:

```
<div style="width: 745px; height: 404px; border: 2.50px black solid; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: inline-flex">
  <div style="align-self: stretch; padding-left: 25px; padding-right: 25px; padding-top: 16px; padding-bottom: 16px; background: white; justify-content: flex-start; align-items: flex-start; gap: 25px; display: inline-flex">
    <div style="width: 215px; height: 170px; background: #ED2020"></div>
    <div style="width: 215px; height: 170px; background: #3C20ED"></div>
    <div style="width: 215px; height: 170px; background: #2C7612"></div>
  </div>
  <div style="align-self: stretch; padding-left: 25px; padding-right: 25px; padding-top: 16px; padding-bottom: 16px; background: white; justify-content: space-between; align-items: flex-start; gap: 50px; display: inline-flex">
    <div style="width: 215px; height: 170px; background: #ED2020"></div>
    <div style="width: 215px; height: 170px; background: #3C20ED"></div>
    <div style="width: 215px; height: 170px; background: #2C7612"></div>
  </div>
</div>
```

Which renders like this:

![Screenshot 2023-08-17 at 11 57 58](https://github.com/bernaferrari/FigmaToCode/assets/69250922/1e5f3cf2-c4aa-44af-b345-90cc73187224)

To accommodate the gap, the width of the squares in the second row are reduced. With this fix, the generated html will not include the gap: 50px property and the rows will render identically as they are in the design.

![Screenshot 2023-08-17 at 13 40 40](https://github.com/bernaferrari/FigmaToCode/assets/69250922/218b7fa7-604f-4389-83d9-ada5a20dfc1d)

I've updated both the HTML and Tailwind generation, however, I am not familiar with either Flutter or Swift so the problem may exist there too.