### PR TITLE
Support fontFamily in Tailwind

### DIFF
--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -36,6 +36,7 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
         color,
         this.fontSize(segment.fontSize),
         this.fontWeight(segment.fontWeight),
+        this.fontFamily(segment.fontName),
         textDecoration,
         textTransform,
         lineHeightStyle,
@@ -95,10 +96,9 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
     return `pl-${Math.round(indentation)}`;
   };
 
-  // todo fontFamily
-  //  fontFamily(node: TextNode): this {
-  //    return this;
-  //  }
+  fontFamily = (fontName: FontName): string => {
+    return "font-['" + fontName.family + "']";
+  };
 
   /**
    * https://tailwindcss.com/docs/font-size/


### PR DESCRIPTION
Solution to #83 

Ideally we'd look to use `font-sans`, `font-serif`, `font-mono`, any any custom classes, but given FigmaToCode doesn't have knowledge of the tailwind config file, we can't look up that mapping. This change still gets the job done and is better than not having anything IMO.