### PR TITLE
feat(tailwind colors): add exact colors, style, and color name

### DIFF
--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -25,6 +25,8 @@ const defaultPluginSettings: PluginSettings = {
   flutterGenerationMode: "snippet",
   swiftUIGenerationMode: "snippet",
   roundTailwind: false,
+  preferColorAlias: false,
+  roundTailwindColors: true,
 };
 
 // A helper type guard to ensure the key belongs to the PluginSettings type

--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -66,9 +66,9 @@ const initSettings = async () => {
   safeRun(userPluginSettings);
 };
 
-const safeRun = (settings: PluginSettings) => {
+const safeRun = async (settings: PluginSettings) => {
   try {
-    run(settings);
+    await run(settings);
   } catch (e) {
     if (e && typeof e === "object" && "message" in e) {
       console.log("error: ", (e as any).stack);
@@ -83,8 +83,8 @@ const safeRun = (settings: PluginSettings) => {
 const standardMode = async () => {
   figma.showUI(__html__, { width: 450, height: 550, themeColors: true });
   await initSettings();
-  figma.on("selectionchange", () => {
-    safeRun(userPluginSettings);
+  figma.on("selectionchange", async () => {
+    await safeRun(userPluginSettings);
   });
   figma.ui.onmessage = (msg) => {
     console.log("[node] figma.ui.onmessage", msg);
@@ -105,7 +105,7 @@ const codegenMode = async () => {
   // figma.showUI(__html__, { visible: false });
   await getUserSettings();
 
-  figma.codegen.on("generate", ({ language, node }) => {
+  figma.codegen.on("generate", async ({ language, node }) => {
     const convertedSelection = convertIntoNodes([node], null);
 
     switch (language) {
@@ -147,7 +147,7 @@ const codegenMode = async () => {
         return [
           {
             title: `Code`,
-            code: tailwindMain(convertedSelection, {
+            code: await tailwindMain(convertedSelection, {
               ...userPluginSettings,
               jsx: false,
             }),
@@ -155,7 +155,7 @@ const codegenMode = async () => {
           },
           {
             title: `Colors`,
-            code: retrieveGenericSolidUIColors("Tailwind")
+            code: (await retrieveGenericSolidUIColors("Tailwind"))
               .map((d) => `#${d.hex} <- ${d.colorName}`)
               .join("\n"),
             language: "HTML",
@@ -170,7 +170,7 @@ const codegenMode = async () => {
         return [
           {
             title: `Code`,
-            code: tailwindMain(convertedSelection, {
+            code: await tailwindMain(convertedSelection, {
               ...userPluginSettings,
               jsx: true,
             }),
@@ -183,7 +183,7 @@ const codegenMode = async () => {
           // },
           {
             title: `Colors`,
-            code: retrieveGenericSolidUIColors("Tailwind")
+            code: (await retrieveGenericSolidUIColors("Tailwind"))
               .map((d) => `#${d.hex} <- ${d.colorName}`)
               .join("\n"),
             language: "HTML",

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
   "networkAccess": {
     "allowedDomains": ["none"]
   },
+  "documentAccess": "dynamic-page",
   "codegenLanguages": [
     { "label": "HTML", "value": "html" },
     { "label": "React (JSX)", "value": "html_jsx" },

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -20,6 +20,8 @@ export type PluginSettings = {
   flutterGenerationMode: string;
   swiftUIGenerationMode: string;
   roundTailwind: boolean;
+  roundTailwindColors: boolean;
+  preferColorAlias: boolean;
 };
 
 export const run = (settings: PluginSettings) => {

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -24,7 +24,7 @@ export type PluginSettings = {
   preferColorAlias: boolean;
 };
 
-export const run = (settings: PluginSettings) => {
+export const run = async (settings: PluginSettings) => {
   // ignore when nothing was selected
   if (figma.currentPage.selection.length === 0) {
     figma.ui.postMessage({
@@ -43,7 +43,7 @@ export const run = (settings: PluginSettings) => {
       result = htmlMain(convertedSelection, settings);
       break;
     case "Tailwind":
-      result = tailwindMain(convertedSelection, settings);
+      result = await tailwindMain(convertedSelection, settings);
       break;
     case "Flutter":
       result = flutterMain(convertedSelection, settings);
@@ -74,8 +74,8 @@ export const run = (settings: PluginSettings) => {
             ),
           }
         : null,
-    colors: retrieveGenericSolidUIColors(settings.framework),
-    gradients: retrieveGenericGradients(settings.framework),
+    colors: await retrieveGenericSolidUIColors(settings.framework),
+    gradients: await retrieveGenericGradients(settings.framework),
     preferences: settings,
     // text: retrieveTailwindText(convertedSelection),
   });

--- a/packages/backend/src/common/commonStyles.ts
+++ b/packages/backend/src/common/commonStyles.ts
@@ -1,9 +1,9 @@
 export interface SupportedNodeForPaintStyle extends Omit<MinimalFillsMixin, "setFillStyleIdAsync"> {}
 
-export function nodePaintStyle(node: SupportedNodeForPaintStyle): PaintStyle | undefined {
+export async function nodePaintStyle(node: SupportedNodeForPaintStyle): Promise<PaintStyle | undefined> {
 	if (node.fillStyleId && node.fillStyleId != figma.mixed) {
 		// TODO: handle mixed mode, maybe ?
-		const style = figma.getStyleById(node.fillStyleId)
+		const style = await figma.getStyleByIdAsync(node.fillStyleId)
 		switch (style?.type) {
 			case "PAINT": 
 				return style

--- a/packages/backend/src/common/commonStyles.ts
+++ b/packages/backend/src/common/commonStyles.ts
@@ -1,0 +1,13 @@
+export interface SupportedNodeForPaintStyle extends Omit<MinimalFillsMixin, "setFillStyleIdAsync"> {}
+
+export function nodePaintStyle(node: SupportedNodeForPaintStyle): PaintStyle | undefined {
+	if (node.fillStyleId && node.fillStyleId != figma.mixed) {
+		// TODO: handle mixed mode, maybe ?
+		const style = figma.getStyleById(node.fillStyleId)
+		switch (style?.type) {
+			case "PAINT": 
+				return style
+				break
+		}
+	}
+}

--- a/packages/backend/src/common/commonVariables.ts
+++ b/packages/backend/src/common/commonVariables.ts
@@ -1,4 +1,4 @@
 
-export function variableNameFromAliasIfAny(alias: VariableAlias | undefined) {
-  return alias ? figma.variables.getVariableById(alias.id)?.name : undefined
+export async function variableNameFromAliasIfAny(alias: VariableAlias | undefined): Promise<string | undefined> {
+  return alias ? (await figma.variables.getVariableByIdAsync(alias.id))?.name : undefined
 }

--- a/packages/backend/src/common/commonVariables.ts
+++ b/packages/backend/src/common/commonVariables.ts
@@ -1,0 +1,4 @@
+
+export function variableNameFromAliasIfAny(alias: VariableAlias | undefined) {
+  return alias ? figma.variables.getVariableById(alias.id)?.name : undefined
+}

--- a/packages/backend/src/common/retrieveFill.ts
+++ b/packages/backend/src/common/retrieveFill.ts
@@ -1,9 +1,9 @@
 /**
  * Retrieve the first visible color that is being used by the layer, in case there are more than one.
  */
-export const retrieveTopFill = (
-  fills: ReadonlyArray<Paint> | PluginAPI["mixed"]
-): Paint | undefined => {
+export const retrieveTopFill = <PaintType extends Paint>(
+  fills: ReadonlyArray<PaintType> | PluginAPI["mixed"]
+): PaintType | undefined => {
   if (fills && fills !== figma.mixed && fills.length > 0) {
     // on Figma, the top layer is always at the last position
     // reverse, then try to find the first layer that is visible, if any.

--- a/packages/backend/src/tailwind/retrieveUI/retrieveTexts.ts
+++ b/packages/backend/src/tailwind/retrieveUI/retrieveTexts.ts
@@ -4,21 +4,21 @@ import { rgbTo6hex } from "../../common/color";
 import { retrieveTopFill } from "../../common/retrieveFill";
 import { convertFontWeight } from "../../common/convertFontWeight";
 
-export const retrieveTailwindText = (
+export const retrieveTailwindText = async (
   sceneNode: Array<SceneNode>
-): Array<namedText> => {
+): Promise<namedText[]> => {
   // convert to Node and then flatten it. Conversion is necessary because of [tailwindText]
   const selectedText = deepFlatten(sceneNode);
 
   const textStr: Array<namedText> = [];
 
-  selectedText.forEach((node) => {
+  for (const node of selectedText) {
     if (node.type === "TEXT") {
       let layoutBuilder = new TailwindTextBuilder(node, false, false)
         .commonPositionStyles(node, false)
         .textAlign(node);
 
-      const styledHtml = layoutBuilder.getTextSegments(node.id);
+      const styledHtml = await layoutBuilder.getTextSegments(node.id);
 
       let content = "";
       if (styledHtml.length === 1) {
@@ -64,7 +64,7 @@ export const retrieveTailwindText = (
         contrastBlack,
       });
     }
-  });
+  };
 
   // retrieve only unique texts (attr + name)
   // from https://stackoverflow.com/a/18923480/4418073

--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -3,13 +3,13 @@ import {
   commonLetterSpacing,
   commonLineHeight,
 } from "../common/commonTextHeightSpacing";
-import { tailwindColorFromFills } from "./builderImpl/tailwindColor";
+import { tailwindSolidColor } from "./builderImpl/tailwindColor.js";
 import {
   pxToFontSize,
   pxToLetterSpacing,
   pxToLineHeight,
 } from "./conversionTables";
-import { TailwindDefaultBuilder } from "./tailwindDefaultBuilder";
+import { TailwindDefaultBuilder, nodePaintFromFills, nodePaintStyleForFigNode } from "./tailwindDefaultBuilder";
 
 export class TailwindTextBuilder extends TailwindDefaultBuilder {
   getTextSegments(id: string): { style: string; text: string }[] {
@@ -19,7 +19,7 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
     }
 
     return segments.map((segment) => {
-      const color = this.getTailwindColorFromFills(segment.fills);
+      const color = this.getTailwindColorFromSegment(segment);
       const textDecoration = this.textDecoration(segment.textDecoration);
       const textTransform = this.textTransform(segment.textCase);
       const lineHeightStyle = this.lineHeight(
@@ -51,13 +51,14 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
     });
   }
 
-  getTailwindColorFromFills = (
-    fills: ReadonlyArray<Paint> | PluginAPI["mixed"]
+  getTailwindColorFromSegment = (
+    segment: StyledTextSegment
   ) => {
     // Implement a function to convert fills to the appropriate Tailwind CSS color classes.
     // This can be based on your project's configuration and color palette.
     // For example, suppose your project uses the default Tailwind CSS color palette:
-    return tailwindColorFromFills(fills, "text");
+    const paint = nodePaintStyleForFigNode(segment)
+    return  paint?.solid ? tailwindSolidColor(paint, paint.opacity ?? 1, "text") : "";
   };
 
   fontSize = (fontSize: number) => {

--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -12,14 +12,14 @@ import {
 import { TailwindDefaultBuilder, nodePaintFromFills, nodePaintStyleForFigNode } from "./tailwindDefaultBuilder";
 
 export class TailwindTextBuilder extends TailwindDefaultBuilder {
-  getTextSegments(id: string): { style: string; text: string }[] {
+  async getTextSegments(id: string): Promise<{ style: string; text: string; }[]> {
     const segments = globalTextStyleSegments[id];
     if (!segments) {
       return [];
     }
 
-    return segments.map((segment) => {
-      const color = this.getTailwindColorFromSegment(segment);
+    return await Promise.all(segments.map(async (segment) => {
+      const color = await this.getTailwindColorFromSegment(segment);
       const textDecoration = this.textDecoration(segment.textDecoration);
       const textTransform = this.textTransform(segment.textCase);
       const lineHeightStyle = this.lineHeight(
@@ -48,16 +48,16 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
 
       const charsWithLineBreak = segment.characters.split("\n").join("<br/>");
       return { style: styleClasses, text: charsWithLineBreak };
-    });
+    }));
   }
 
-  getTailwindColorFromSegment = (
+  getTailwindColorFromSegment = async(
     segment: StyledTextSegment
   ) => {
     // Implement a function to convert fills to the appropriate Tailwind CSS color classes.
     // This can be based on your project's configuration and color palette.
     // For example, suppose your project uses the default Tailwind CSS color palette:
-    const paint = nodePaintStyleForFigNode(segment)
+    const paint = await nodePaintStyleForFigNode(segment)
     return  paint?.solid ? tailwindSolidColor(paint, paint.opacity ?? 1, "text") : "";
   };
 

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -16,6 +16,8 @@ export type PluginSettings = {
   flutterGenerationMode: string;
   swiftUIGenerationMode: string;
   roundTailwind: boolean;
+  roundTailwindColors: boolean;
+  preferColorAlias: boolean;
 };
 
 type PluginUIProps = {
@@ -207,6 +209,20 @@ export const preferenceOptions: LocalCodegenPreference[] = [
     propertyName: "roundTailwind",
     label: "Round to Tailwind Values",
     isDefault: false,
+    includedLanguages: ["Tailwind"],
+  },
+  {
+    itemType: "individual_select",
+    propertyName: "roundTailwindColors",
+    label: "Round to Tailwind Colors",
+    isDefault: true,
+    includedLanguages: ["Tailwind"],
+  },
+  {
+    itemType: "individual_select",
+    propertyName: "preferColorAlias",
+    label: "Use color alias for CSS class",
+    isDefault: true,
     includedLanguages: ["Tailwind"],
   },
   // Add your preferences data here


### PR DESCRIPTION
 • now supports styles, if a style is used for a figma node, its styles
   take precedence on node fills. (probably need factorization for other
   frameworks)
 • add a setting to only allow named color for exact matches with tailwind
 • use figma name, either alias or style for colors. Those colors
   need to be added to tailwind configuration.