### PR TITLE
Add Tailwind support for Figma variables

### DIFF
--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -24,7 +24,9 @@ const defaultPluginSettings: PluginSettings = {
   responsiveRoot: false,
   flutterGenerationMode: "snippet",
   swiftUIGenerationMode: "snippet",
-  roundTailwind: false,
+  roundTailwindValues: false,
+  roundTailwindColors: false,
+  customTailwindColors: false,
 };
 
 // A helper type guard to ensure the key belongs to the PluginSettings type

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -19,7 +19,9 @@ export type PluginSettings = {
   responsiveRoot: boolean;
   flutterGenerationMode: string;
   swiftUIGenerationMode: string;
-  roundTailwind: boolean;
+  roundTailwindValues: boolean;
+  roundTailwindColors: boolean,
+  customTailwindColors: boolean,
 };
 
 export const run = (settings: PluginSettings) => {

--- a/packages/backend/src/common/retrieveUI/retrieveColors.ts
+++ b/packages/backend/src/common/retrieveUI/retrieveColors.ts
@@ -4,10 +4,11 @@ import {
   swiftuiGradient,
 } from "../../swiftui/builderImpl/swiftuiColor";
 import {
+  getTailwindFromVariable,
   tailwindColors,
   tailwindGradient,
   tailwindNearestColor,
-  tailwindSolidColor,
+  tailwindSolidColor
 } from "../../tailwind/builderImpl/tailwindColor";
 import {
   flutterColor,
@@ -68,8 +69,11 @@ const convertSolidColor = (
     const kind = "solid";
     const hex = rgbTo6hex(fill.color);
     const hexNearestColor = tailwindNearestColor(hex);
-    exported = tailwindSolidColor(fill.color, fill.opacity, kind);
-    colorName = tailwindColors[hexNearestColor];
+    const colorVar = fill.boundVariables?.color
+    exported = tailwindSolidColor(fill, kind);
+    colorName = colorVar
+      ? getTailwindFromVariable(colorVar)
+      : tailwindColors[hexNearestColor];
   } else if (framework === "SwiftUI") {
     exported = swiftuiColor(fill.color, opacity);
   }

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -46,17 +46,12 @@ export const tailwindSolidColor = (fill: SolidPaint | ColorStop, kind?: string):
   }
 
   // grab opacity, or set it to full
-  const opacity = "opacity" in fill
-    ? fill.opacity ?? 1
-    : 1
-
-  // example: opacity-50
-  const opacityProp = opacity !== 1.0
-    ? `opacity-${nearestOpacity(opacity ?? 1.0)}`
+  const opacity = "opacity" in fill && fill.opacity !== 1.0
+    ? `/${nearestOpacity(fill.opacity ?? 1.0)}`
     : "";
 
-  // example: text-red-500, text-custom-color-700/opacity-25
-  return `${kind}-${colorName}${opacityProp ? `/${opacityProp}` : ""}`
+  // example: text-red-500, text-custom-color-700/25
+  return `${kind}-${colorName}${opacity}`
 };
 
 /**

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -13,7 +13,7 @@ export const tailwindColorFromFills = (
 
   const fill = retrieveTopFill(fills);
   if (fill && fill.type === "SOLID") {
-    return tailwindSolidColor(fill.color, fill.opacity, kind);
+    return tailwindSolidColor(fill, kind)
   } else if (
     fill &&
     (fill.type === "GRADIENT_LINEAR" ||
@@ -22,32 +22,42 @@ export const tailwindColorFromFills = (
       fill.type === "GRADIENT_DIAMOND")
   ) {
     if (fill.gradientStops.length > 0) {
-      return tailwindSolidColor(
-        fill.gradientStops[0].color,
-        fill.opacity,
-        kind
-      );
+      return tailwindSolidColor(fill.gradientStops[0], kind);
     }
   }
   return "";
 };
 
-export const tailwindSolidColor = (
-  color: RGB,
-  opacity: number | undefined,
-  kind: string
-): string => {
-  // example: text-opacity-50
-  // ignore the 100. If opacity was changed, let it be visible.
-  const opacityProp =
-    opacity !== 1.0 ? `opacity-${nearestOpacity(opacity ?? 1.0)}` : null;
+/**
+ * Get the tailwind token name for a given color
+ *
+ * - variables: uses the tokenised variable name
+ * - colors:    uses the nearest Tailwind color name
+ */
+export function tailwindSolidColor(fill: SolidPaint | ColorStop, kind?: string): string {
+  // example: stone-500 or custom-color-700
+  const colorName = fill.boundVariables?.color
+    ? getTailwindFromVariable(fill.boundVariables.color)
+    : getTailwindFromFigmaRGB(fill.color);
 
-  // example: text-red-500
-  const colorProp = `${kind}-${getTailwindFromFigmaRGB(color)}${opacityProp ? `/${opacityProp}` : ""}`;
+  // if no kind, it's a variable stop, so just return the name
+  if (!kind) {
+    return colorName
+  }
 
-  // if fill isn't visible, it shouldn't be painted.
-  return colorProp;
-};
+  // grab opacity, or set it to full
+  const opacity = "opacity" in fill
+    ? fill.opacity ?? 1
+    : 1
+
+  // example: opacity-50
+  const opacityProp = opacity !== 1.0
+    ? `opacity-${nearestOpacity(opacity ?? 1.0)}`
+    : "";
+
+  // example: text-red-500, text-custom-color-700/opacity-25
+  return `${kind}-${colorName}${opacityProp ? `/${opacityProp}` : ""}`
+}
 
 /**
  * https://tailwindcss.com/docs/box-shadow/
@@ -71,24 +81,22 @@ export const tailwindGradient = (fill: GradientPaint): string => {
   const direction = gradientDirection(gradientAngle(fill));
 
   if (fill.gradientStops.length === 1) {
-    const fromColor = getTailwindFromFigmaRGB(fill.gradientStops[0].color);
+    const fromColor = tailwindSolidColor(fill.gradientStops[0]);
 
     return `${direction} from-${fromColor}`;
   } else if (fill.gradientStops.length === 2) {
-    const fromColor = getTailwindFromFigmaRGB(fill.gradientStops[0].color);
-    const toColor = getTailwindFromFigmaRGB(fill.gradientStops[1].color);
+    const fromColor = tailwindSolidColor(fill.gradientStops[0]);
+    const toColor = tailwindSolidColor(fill.gradientStops[1]);
 
     return `${direction} from-${fromColor} to-${toColor}`;
   } else {
-    const fromColor = getTailwindFromFigmaRGB(fill.gradientStops[0].color);
+    const fromColor = tailwindSolidColor(fill.gradientStops[0]);
 
     // middle (second color)
-    const viaColor = getTailwindFromFigmaRGB(fill.gradientStops[1].color);
+    const viaColor = tailwindSolidColor(fill.gradientStops[1]);
 
     // last
-    const toColor = getTailwindFromFigmaRGB(
-      fill.gradientStops[fill.gradientStops.length - 1].color
-    );
+    const toColor = tailwindSolidColor(fill.gradientStops[fill.gradientStops.length - 1]);
 
     return `${direction} from-${fromColor} via-${viaColor} to-${toColor}`;
   }
@@ -378,6 +386,6 @@ export const getTailwindFromFigmaRGB = (color: RGB): string => {
   return tailwindColors[tailwindNearestColor(colorMultiplied)];
 };
 
-export const getTailwindColor = (color: string | RGB): string => {
-  return tailwindColors[tailwindNearestColor(color)];
-};
+export const getTailwindFromVariable = (alias: VariableAlias) => {
+  return figma.variables.getVariableById(alias.id)?.name.replaceAll("/", "-") || alias.id
+}

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -34,7 +34,7 @@ export const tailwindColorFromFills = (
  * - variables: uses the tokenised variable name
  * - colors:    uses the nearest Tailwind color name
  */
-export function tailwindSolidColor(fill: SolidPaint | ColorStop, kind?: string): string {
+export const tailwindSolidColor = (fill: SolidPaint | ColorStop, kind?: string): string => {
   // example: stone-500 or custom-color-700
   const colorName = fill.boundVariables?.color
     ? getTailwindFromVariable(fill.boundVariables.color)
@@ -57,7 +57,7 @@ export function tailwindSolidColor(fill: SolidPaint | ColorStop, kind?: string):
 
   // example: text-red-500, text-custom-color-700/opacity-25
   return `${kind}-${colorName}${opacityProp ? `/${opacityProp}` : ""}`
-}
+};
 
 /**
  * https://tailwindcss.com/docs/box-shadow/

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -1,7 +1,8 @@
 import { nearestColorFrom } from "../../nearest-color/nearestColor";
 import { retrieveTopFill } from "../../common/retrieveFill";
-import { gradientAngle } from "../../common/color";
+import { gradientAngle, rgbTo6hex } from "../../common/color";
 import { nearestOpacity, nearestValue } from "../conversionTables";
+import { localTailwindSettings } from "../tailwindMain";
 
 // retrieve the SOLID color for tailwind
 export const tailwindColorFromFills = (
@@ -36,9 +37,11 @@ export const tailwindColorFromFills = (
  */
 export const tailwindSolidColor = (fill: SolidPaint | ColorStop, kind?: string): string => {
   // example: stone-500 or custom-color-700
-  const colorName = fill.boundVariables?.color
+  const colorName = localTailwindSettings.customTailwindColors && fill.boundVariables?.color
     ? getTailwindFromVariable(fill.boundVariables.color)
-    : getTailwindFromFigmaRGB(fill.color);
+    : localTailwindSettings.roundTailwindColors
+      ? getTailwindFromFigmaRGB(fill.color)
+      : `[#${rgbTo6hex(fill.color)}]`;
 
   // if no kind, it's a variable stop, so just return the name
   if (!kind) {

--- a/packages/backend/src/tailwind/conversionTables.ts
+++ b/packages/backend/src/tailwind/conversionTables.ts
@@ -37,7 +37,7 @@ const pxToRemToTailwind = (
 
   if (convertedValue) {
     return conversionMap[convertedValue];
-  } else if (localTailwindSettings.roundTailwind) {
+  } else if (localTailwindSettings.roundTailwindValues) {
     return conversionMap[nearestValue(value / 16, keys)];
   }
 
@@ -53,7 +53,7 @@ const pxToTailwind = (
 
   if (convertedValue) {
     return conversionMap[convertedValue];
-  } else if (localTailwindSettings.roundTailwind) {
+  } else if (localTailwindSettings.roundTailwindValues) {
     return conversionMap[nearestValue(value, keys)];
   }
 

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -15,7 +15,9 @@ export type PluginSettings = {
   responsiveRoot: boolean;
   flutterGenerationMode: string;
   swiftUIGenerationMode: string;
-  roundTailwind: boolean;
+  roundTailwindValues: boolean;
+  roundTailwindColors: boolean;
+  customTailwindColors: boolean;
 };
 
 type PluginUIProps = {
@@ -191,21 +193,35 @@ export const preferenceOptions: LocalCodegenPreference[] = [
   {
     itemType: "individual_select",
     propertyName: "optimizeLayout",
-    label: "Optimize Layout",
+    label: "Optimize layout",
     isDefault: true,
     includedLanguages: ["HTML", "Tailwind", "Flutter", "SwiftUI"],
   },
   {
     itemType: "individual_select",
     propertyName: "layerName",
-    label: "Layer Names",
+    label: "Include layer names in classes",
     isDefault: false,
     includedLanguages: ["HTML", "Tailwind"],
   },
   {
     itemType: "individual_select",
-    propertyName: "roundTailwind",
-    label: "Round to Tailwind Values",
+    propertyName: "roundTailwindValues",
+    label: "Round pixel values to Tailwind defaults",
+    isDefault: false,
+    includedLanguages: ["Tailwind"],
+  },
+  {
+    itemType: "individual_select",
+    propertyName: "roundTailwindColors",
+    label: "Round color values to Tailwind defaults",
+    isDefault: false,
+    includedLanguages: ["Tailwind"],
+  },
+  {
+    itemType: "individual_select",
+    propertyName: "customTailwindColors",
+    label: "Use variables as custom color tokens",
     isDefault: false,
     includedLanguages: ["Tailwind"],
   },

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -163,6 +163,7 @@ type LocalCodegenPreference =
       "framework" | "flutterGenerationMode" | "swiftUIGenerationMode"
     >;
     label: string;
+    description: string;
     value?: boolean;
     isDefault?: boolean;
     includedLanguages?: FrameworkTypes[];
@@ -173,6 +174,7 @@ export const preferenceOptions: LocalCodegenPreference[] = [
     itemType: "individual_select",
     propertyName: "jsx",
     label: "React (JSX)",
+    description: 'Render "class" attributes as "className"',
     isDefault: false,
     includedLanguages: ["HTML", "Tailwind"],
   },
@@ -194,34 +196,39 @@ export const preferenceOptions: LocalCodegenPreference[] = [
     itemType: "individual_select",
     propertyName: "optimizeLayout",
     label: "Optimize layout",
+    description: 'Attempt to auto-layout suitable element groups',
     isDefault: true,
     includedLanguages: ["HTML", "Tailwind", "Flutter", "SwiftUI"],
   },
   {
     itemType: "individual_select",
     propertyName: "layerName",
-    label: "Include layer names in classes",
+    label: "Layer names",
+    description: 'Include layer names in classes',
     isDefault: false,
     includedLanguages: ["HTML", "Tailwind"],
   },
   {
     itemType: "individual_select",
     propertyName: "roundTailwindValues",
-    label: "Round pixel values to Tailwind defaults",
+    label: "Round values",
+    description: 'Round pixel values to nearest Tailwind sizes',
     isDefault: false,
     includedLanguages: ["Tailwind"],
   },
   {
     itemType: "individual_select",
     propertyName: "roundTailwindColors",
-    label: "Round color values to Tailwind defaults",
+    label: "Round colors",
+    description: 'Round color values to nearest Tailwind colors',
     isDefault: false,
     includedLanguages: ["Tailwind"],
   },
   {
     itemType: "individual_select",
     propertyName: "customTailwindColors",
-    label: "Use variables as custom color tokens",
+    label: "Custom colors",
+    description: 'Use color variable names as custom color names',
     isDefault: false,
     includedLanguages: ["Tailwind"],
   },
@@ -334,6 +341,7 @@ export const CodePanel = (props: {
                 <SelectableToggle
                   key={preference.propertyName}
                   title={preference.label}
+                  description={preference.description}
                   isSelected={
                     props.preferences?.[preference.propertyName] ??
                     preference.isDefault
@@ -563,6 +571,7 @@ type SelectableToggleProps = {
   onSelect: (isSelected: boolean) => void;
   isSelected?: boolean;
   title: string;
+  description?: string;
   buttonClass: string;
   checkClass: string;
 };
@@ -571,6 +580,7 @@ const SelectableToggle = ({
   onSelect,
   isSelected = false,
   title,
+  description,
   buttonClass,
   checkClass,
 }: SelectableToggleProps) => {
@@ -581,6 +591,7 @@ const SelectableToggle = ({
   return (
     <button
       onClick={handleClick}
+      title={description}
       className={`h-8 px-2 truncate flex items-center justify-center rounded-md cursor-pointer transition-all duration-300
       hover:bg-neutral-200 dark:hover:bg-neutral-700 gap-2 text-sm ring-1 
       ${


### PR DESCRIPTION
This PR modifies the Tailwind color functions to support Figma variables.

This allows users to use custom variables in their design systems, such as `neutral/700` or `buttons/active-border` which then output as classes such as `bg-neutral-700` or `border-buttons-active-border`:

![CleanShot 2024-06-28 at 17 33 34](https://github.com/bernaferrari/FigmaToCode/assets/132681/427c53a7-12c9-42be-9731-0d58931cb493)

The main update to the code is that rather than passing in a `color` and `opacity`, you pass the entire `fill` or `color stop` and the function's code returns the color name as-is if it's a variable, or looks up the nearest value if not.

Output looks like this:

```html
<div class="w-44 h-36 relative">
  <div class="w-20 h-36 left-0 top-0 absolute">
    <div class="left-[16px] top-0 absolute text-neutral-900 text-xs font-normal font-['Inter']">Variables</div>
    <div class="w-20 h-28 left-0 top-[27px] absolute">
      <div class="w-8 h-8 left-0 top-0 absolute bg-test-dragon"></div>
      <div class="w-8 h-8 left-[44px] top-0 absolute bg-test-dragon-light/opacity-25"></div>
      <div class="w-8 h-8 left-0 top-[44px] absolute bg-gradient-to-b from-test-dragon to-test-sky"></div>
      <div class="w-8 h-8 left-[44px] top-[44px] absolute bg-gradient-to-b from-test-dragon to-test-sky"></div>
      <div class="w-8 h-8 left-[44px] top-[88px] absolute bg-gradient-to-b from-test-dragon via-green-300 to-test-sky"></div>
    </div>
  </div>
  <div class="w-20 h-24 left-[103px] top-0 absolute">
    <div class="left-[16px] top-0 absolute text-neutral-800 text-xs font-normal font-['Inter']">Colors</div>
    <div class="w-20 h-20 left-0 top-[27px] absolute">
      <div class="w-8 h-8 left-0 top-0 absolute bg-lime-400"></div>
      <div class="w-8 h-8 left-[44px] top-0 absolute bg-lime-400/opacity-25"></div>
      <div class="w-8 h-8 left-0 top-[44px] absolute bg-gradient-to-b from-lime-400 to-cyan-400"></div>
      <div class="w-8 h-8 left-[44px] top-[44px] absolute bg-gradient-to-b from-lime-400 to-cyan-400"></div>
    </div>
  </div>
</div>
```

I couldn't get the tests to run (should Jest not be installed in the project? Maybe you can explain what I'm missing!) but I think as all the tests use interim functions, they should run fine.

You may want to add tests for variables (I assume `figma.variables.getVariableById()` will need a mock):

```json
{
    "type": "SOLID",
    "visible": true,
    "opacity": 1,
    "blendMode": "NORMAL",
    "color": {
        "r": 0.8901960849761963,
        "g": 0.24313725531101227,
        "b": 0.24313725531101227
    },
    "boundVariables": {
        "color": {
            "type": "VARIABLE_ALIAS",
            "id": "VariableID:1:22"
        }
    }
}
```

> **EDIT:** Ah; I see: [The tests were disabled on the last version in favor of the debug UI](https://github.com/bernaferrari/FigmaToCode/issues/79#issuecomment-1766500640)

Closes #107

Relates to #102