### PR TITLE
Add Tailwind support for horizontal-resize / hug

### DIFF
--- a/packages/backend/src/tailwind/builderImpl/tailwindSize.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindSize.ts
@@ -14,7 +14,11 @@ export const tailwindSizePartial = (
       : null) ?? node.parent;
 
   let w = "";
-  if (typeof size.width === "number") {
+  if (
+    typeof size.width === "number" &&
+    'layoutSizingHorizontal' in node &&
+    node.layoutSizingHorizontal === 'FIXED'
+  ) {
     w = `w-${pxToLayoutSize(size.width)}`;
   } else if (size.width === "fill") {
     if (


### PR DESCRIPTION
> Wasn't too sure what to name this PR; feel free to change.

### ✅ Hugging

This solves the `hug` part of #82, so:

- when horizontal resizing is set to `hug`, the Tailwind width class is omitted

### ⏸️ Wrapping

However, wrapping needs more work:

- for auto-layout `wrap`, the `flex-wrap` class will need to be added
- for wrapping alignment other than `top-*` I think `justify-*` needs to be changed to `content-*`
  - I think it should only be `justify` when `counterAxisAlignContent` is `SPACE_BETWEEN` ?
- support could also be added for `gap-x` and `gap-y`

I did some basic layouts just to check:

![CleanShot 2024-07-02 at 22 36 25](https://github.com/bernaferrari/FigmaToCode/assets/132681/0c617e9d-cca8-4517-81da-b1f4fd1258a6)

The following is modified Tailwind code [in the playground](https://play.tailwindcss.com/Ofpvu2qLYv):

![CleanShot 2024-07-02 at 22 32 52](https://github.com/bernaferrari/FigmaToCode/assets/132681/86e40347-d5b7-41a5-9c6b-9452da2ce389)

```html
<!-- https://play.tailwindcss.com/Ofpvu2qLYv -->
<div class="flex items-center justify-center h-screen w-screen">
  <div class="flex flex-wrap justify-end content-end gap-6 w-56 h-44 p-3 outline-dashed outline-2">
    <div class="min-h-10 min-w-10 bg-cyan-100"></div>
    <div class="min-h-10 min-w-10 bg-blue-200"></div>
    <div class="min-h-10 min-w-10 bg-lime-400"></div>
    <div class="min-h-10 min-w-10 bg-teal-500"></div>
  </div>
</div>
```

Happy to continue looking at this, but very aware that I'm no TW expert so will happily take advice.