### PR TITLE
Warning log

### DIFF
--- a/apps/debug/pages/index.tsx
+++ b/apps/debug/pages/index.tsx
@@ -21,7 +21,6 @@ export default function Web() {
               code={
                 "backend:dev: CJS dist/index.js 105.74 KB backend:dev: CJS ⚡️ Build        success in 419ms plugin:dev: warn - Port 3000 is in use, trying 3001        instead. plugin:dev: warn - Port 3001 is in use, trying 3002 instead."
               }
-              emptySelection={false}
               selectedFramework={selectedFramework}
               setSelectedFramework={setSelectedFramework}
               htmlPreview={null}
@@ -41,7 +40,6 @@ export default function Web() {
               code={"code goes hereeeee"}
               selectedFramework={selectedFramework}
               setSelectedFramework={setSelectedFramework}
-              emptySelection={false}
               htmlPreview={null}
               settings={undefined}
               onPreferenceChanged={() => {}}

--- a/apps/debug/pages/index.tsx
+++ b/apps/debug/pages/index.tsx
@@ -6,6 +6,8 @@ export default function Web() {
   const [selectedFramework, setSelectedFramework] =
     React.useState<FrameworkTypes>("HTML");
 
+  const testWarnings = ["This is an example of a conversion warning message."];
+
   return (
     <div className="flex flex-col p-8 space-y-2">
       <p className="text-3xl font-bold">Debug Mode</p>
@@ -27,6 +29,7 @@ export default function Web() {
               onPreferenceChanged={() => {}}
               colors={[]}
               gradients={[]}
+              warnings={testWarnings}
             />
           </div>
         </div>
@@ -44,6 +47,7 @@ export default function Web() {
               onPreferenceChanged={() => {}}
               colors={[]}
               gradients={[]}
+              warnings={testWarnings}
             />
           </div>
         </div>

--- a/apps/plugin/ui-src/App.tsx
+++ b/apps/plugin/ui-src/App.tsx
@@ -71,7 +71,7 @@ export default function App() {
           // const emptyMessage = untypedMessage as EmptyMessage;
           setState((prevState) => ({
             ...prevState,
-            code: "// No layer is selected.",
+            code: "",
             htmlPreview: emptyPreview,
             warnings: [],
             colors: [],
@@ -136,7 +136,6 @@ export default function App() {
       <PluginUI
         code={state.code}
         warnings={state.warnings}
-        emptySelection={false}
         selectedFramework={state.selectedFramework}
         setSelectedFramework={handleFrameworkChange}
         htmlPreview={state.htmlPreview}

--- a/apps/plugin/ui-src/App.tsx
+++ b/apps/plugin/ui-src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-<<<<<<< HEAD
 import { PluginUI } from "plugin-ui";
 import {
   FrameworkTypes,
@@ -11,38 +10,19 @@ import {
   SolidColorConversion,
   ErrorMessage,
   SettingsChangedMessage,
+  Warning,
 } from "types";
 import { postUISettingsChangingMessage } from "./messaging";
-=======
-import { FrameworkTypes, PluginSettings, PluginUI } from "plugin-ui";
-import { Warnings } from "backend/src/common/commonConversionWarnings";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 interface AppState {
   code: string;
   selectedFramework: FrameworkTypes;
   isLoading: boolean;
-<<<<<<< HEAD
   htmlPreview: HTMLPreview;
   settings: PluginSettings | null;
   colors: SolidColorConversion[];
   gradients: LinearGradientConversion[];
-=======
-  htmlPreview: {
-    size: { width: number; height: number };
-    content: string;
-  } | null;
-  preferences: PluginSettings | null;
-  colors: {
-    hex: string;
-    colorName: string;
-    exportValue: string;
-    contrastWhite: number;
-    contrastBlack: number;
-  }[];
-  gradients: { cssPreview: string; exportedValue: string }[];
-  warnings: string[];
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
+  warnings: Warning[];
 }
 
 const emptyPreview = { size: { width: 0, height: 0 }, content: "" };
@@ -73,18 +53,8 @@ export default function App() {
           const conversionMessage = untypedMessage as ConversionMessage;
           setState((prevState) => ({
             ...prevState,
-<<<<<<< HEAD
             ...conversionMessage,
             selectedFramework: conversionMessage.settings.framework,
-=======
-            code: message.data,
-            htmlPreview: message.htmlPreview,
-            colors: message.colors,
-            gradients: message.gradients,
-            preferences: message.preferences,
-            selectedFramework: message.preferences.framework,
-            warnings: message.warnings,
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
           }));
           break;
 
@@ -101,14 +71,9 @@ export default function App() {
           // const emptyMessage = untypedMessage as EmptyMessage;
           setState((prevState) => ({
             ...prevState,
-<<<<<<< HEAD
             code: "// No layer is selected.",
             htmlPreview: emptyPreview,
-=======
-            code: "",
             warnings: [],
-            htmlPreview: null,
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
             colors: [],
             gradients: [],
           }));

--- a/apps/plugin/ui-src/App.tsx
+++ b/apps/plugin/ui-src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+<<<<<<< HEAD
 import { PluginUI } from "plugin-ui";
 import {
   FrameworkTypes,
@@ -12,15 +13,36 @@ import {
   SettingsChangedMessage,
 } from "types";
 import { postUISettingsChangingMessage } from "./messaging";
+=======
+import { FrameworkTypes, PluginSettings, PluginUI } from "plugin-ui";
+import { Warnings } from "backend/src/common/commonConversionWarnings";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 interface AppState {
   code: string;
   selectedFramework: FrameworkTypes;
   isLoading: boolean;
+<<<<<<< HEAD
   htmlPreview: HTMLPreview;
   settings: PluginSettings | null;
   colors: SolidColorConversion[];
   gradients: LinearGradientConversion[];
+=======
+  htmlPreview: {
+    size: { width: number; height: number };
+    content: string;
+  } | null;
+  preferences: PluginSettings | null;
+  colors: {
+    hex: string;
+    colorName: string;
+    exportValue: string;
+    contrastWhite: number;
+    contrastBlack: number;
+  }[];
+  gradients: { cssPreview: string; exportedValue: string }[];
+  warnings: string[];
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 }
 
 const emptyPreview = { size: { width: 0, height: 0 }, content: "" };
@@ -33,6 +55,7 @@ export default function App() {
     settings: null,
     colors: [],
     gradients: [],
+    warnings: [],
   });
 
   const rootStyles = getComputedStyle(document.documentElement);
@@ -50,8 +73,18 @@ export default function App() {
           const conversionMessage = untypedMessage as ConversionMessage;
           setState((prevState) => ({
             ...prevState,
+<<<<<<< HEAD
             ...conversionMessage,
             selectedFramework: conversionMessage.settings.framework,
+=======
+            code: message.data,
+            htmlPreview: message.htmlPreview,
+            colors: message.colors,
+            gradients: message.gradients,
+            preferences: message.preferences,
+            selectedFramework: message.preferences.framework,
+            warnings: message.warnings,
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
           }));
           break;
 
@@ -68,8 +101,14 @@ export default function App() {
           // const emptyMessage = untypedMessage as EmptyMessage;
           setState((prevState) => ({
             ...prevState,
+<<<<<<< HEAD
             code: "// No layer is selected.",
             htmlPreview: emptyPreview,
+=======
+            code: "",
+            warnings: [],
+            htmlPreview: null,
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
             colors: [],
             gradients: [],
           }));
@@ -131,6 +170,7 @@ export default function App() {
     <div className={`${figmaColorBgValue === "#ffffff" ? "" : "dark"}`}>
       <PluginUI
         code={state.code}
+        warnings={state.warnings}
         emptySelection={false}
         selectedFramework={state.selectedFramework}
         setSelectedFramework={handleFrameworkChange}

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -8,11 +8,12 @@ import { generateHTMLPreview, htmlMain } from "./html/htmlMain";
 import { postConversionComplete, postEmptyMessage } from "./messaging";
 import { swiftuiMain } from "./swiftui/swiftuiMain";
 import { tailwindMain } from "./tailwind/tailwindMain";
+import { clearWarnings, warnings } from "./common/commonConversionWarnings";
 import { PluginSettings } from "types";
 
 export const run = (settings: PluginSettings) => {
+  clearWarnings();
   const selection = figma.currentPage.selection;
-
   const convertedSelection = convertIntoNodes(selection, null);
 
   // ignore when nothing was selected
@@ -47,6 +48,7 @@ export const run = (settings: PluginSettings) => {
     colors,
     gradients,
     settings,
+    warnings: [...warnings],
   });
 };
 

--- a/packages/backend/src/common/commonConversionWarnings.ts
+++ b/packages/backend/src/common/commonConversionWarnings.ts
@@ -1,0 +1,10 @@
+import { Warning } from "types";
+
+export const warnings = new Set<Warning>();
+export const addWarning = (warning: Warning) => {
+  if (warnings.has(warning) === false) {
+    console.warn(warning);
+  }
+  warnings.add(warning);
+};
+export const clearWarnings = () => warnings.clear();

--- a/packages/backend/src/flutter/builderImpl/flutterColor.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterColor.ts
@@ -1,4 +1,5 @@
 import { rgbTo8hex, gradientAngle } from "../../common/color";
+import { addWarning } from "../../common/commonConversionWarnings";
 import { generateWidgetCode, sliceNum } from "../../common/numToAutoFixed";
 import { retrieveTopFill } from "../../common/retrieveFill";
 import { nearestValue } from "../../tailwind/conversionTables";
@@ -50,6 +51,7 @@ export const flutterBoxDecorationColor = (
 };
 
 export const flutterDecorationImage = (node: SceneNode, fill: ImagePaint) => {
+  addWarning("Image fills are replaced with placeholders");
   return generateWidgetCode("DecorationImage", {
     image: `NetworkImage("https://via.placeholder.com/${node.width.toFixed(
       0,
@@ -82,7 +84,7 @@ export const flutterGradient = (fill: GradientPaint): string => {
     case "GRADIENT_ANGULAR":
       return flutterAngularGradient(fill);
     default:
-      // Diamond gradient is unsupported.
+      addWarning("Diamond dradients are not supported in Flutter");
       return "";
   }
 };

--- a/packages/backend/src/flutter/flutterMain.ts
+++ b/packages/backend/src/flutter/flutterMain.ts
@@ -12,11 +12,8 @@ import {
   getMainAxisAlignment,
 } from "./builderImpl/flutterAutoLayout";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-<<<<<<< HEAD
 import { PluginSettings } from "types";
-=======
 import { addWarning } from "../common/commonConversionWarnings";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let localSettings: PluginSettings;
 let previousExecutionCache: string[];

--- a/packages/backend/src/flutter/flutterMain.ts
+++ b/packages/backend/src/flutter/flutterMain.ts
@@ -12,7 +12,11 @@ import {
   getMainAxisAlignment,
 } from "./builderImpl/flutterAutoLayout";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
+<<<<<<< HEAD
 import { PluginSettings } from "types";
+=======
+import { addWarning } from "../common/commonConversionWarnings";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let localSettings: PluginSettings;
 let previousExecutionCache: string[];
@@ -113,6 +117,9 @@ const flutterWidgetGenerator = (
       case "TEXT":
         comp.push(flutterText(node));
         break;
+      case "VECTOR":
+        addWarning("VectorNodes are not supported in Flutter");
+        break;
       default:
       // do nothing
     }
@@ -143,6 +150,7 @@ const flutterContainer = (node: SceneNode, child: string): string => {
 
   let image = "";
   if ("fills" in node && retrieveTopFill(node.fills)?.type === "IMAGE") {
+    addWarning("Image fills are replaced with placeholders");
     image = `Image.network("https://via.placeholder.com/${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}")`;

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -5,11 +5,8 @@ import { HtmlDefaultBuilder } from "./htmlDefaultBuilder";
 import { htmlAutoLayoutProps } from "./builderImpl/htmlAutoLayout";
 import { formatWithJSX } from "../common/parseJSX";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-<<<<<<< HEAD
 import { PluginSettings } from "types";
-=======
 import { addWarning } from "../common/commonConversionWarnings";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let showLayerNames = false;
 

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -5,7 +5,11 @@ import { HtmlDefaultBuilder } from "./htmlDefaultBuilder";
 import { htmlAutoLayoutProps } from "./builderImpl/htmlAutoLayout";
 import { formatWithJSX } from "../common/parseJSX";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
+<<<<<<< HEAD
 import { PluginSettings } from "types";
+=======
+import { addWarning } from "../common/commonConversionWarnings";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let showLayerNames = false;
 
@@ -87,6 +91,8 @@ const htmlWidgetGenerator = (
         break;
       case "VECTOR":
         comp += htmlAsset(node, isJsx);
+        addWarning("VectorNodes are not fully supported in HTML");
+        break;
     }
   });
 
@@ -208,6 +214,7 @@ export const htmlAsset = (node: SceneNode, isJsx: boolean = false): string => {
   let tag = "div";
   let src = "";
   if (retrieveTopFill(node.fills)?.type === "IMAGE") {
+    addWarning("Image fills are replaced with placeholders");
     tag = "img";
     src = ` src="https://via.placeholder.com/${node.width.toFixed(
       0,
@@ -249,6 +256,7 @@ export const htmlContainer = (
     let tag = "div";
     let src = "";
     if (retrieveTopFill(node.fills)?.type === "IMAGE") {
+      addWarning("Image fills are replaced with placeholders");
       if (!("children" in node) || node.children.length === 0) {
         tag = "img";
         src = ` src="https://via.placeholder.com/${node.width.toFixed(

--- a/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
@@ -2,6 +2,7 @@ import { retrieveTopFill } from "../../common/retrieveFill";
 import { gradientAngle } from "../../common/color";
 import { nearestValue } from "../../tailwind/conversionTables";
 import { sliceNum } from "../../common/numToAutoFixed";
+import { addWarning } from "../../common/commonConversionWarnings";
 
 export const swiftUISolidColor = (fill: Paint): string => {
   if (fill && fill.type === "SOLID") {
@@ -58,6 +59,7 @@ export const swiftuiBackground = (
   } else if (fill?.type === "GRADIENT_LINEAR") {
     return swiftuiGradient(fill);
   } else if (fill?.type === "IMAGE") {
+    addWarning("Image fills are replaced with placeholders");
     return `AsyncImage(url: URL(string: "https://via.placeholder.com/${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}"))`;

--- a/packages/backend/src/swiftui/swiftuiMain.ts
+++ b/packages/backend/src/swiftui/swiftuiMain.ts
@@ -3,11 +3,8 @@ import { stringToClassName, sliceNum } from "../common/numToAutoFixed";
 import { SwiftuiTextBuilder } from "./swiftuiTextBuilder";
 import { SwiftuiDefaultBuilder } from "./swiftuiDefaultBuilder";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-<<<<<<< HEAD
 import { PluginSettings } from "types";
-=======
 import { addWarning } from "../common/commonConversionWarnings";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let localSettings: PluginSettings;
 let previousExecutionCache: string[];

--- a/packages/backend/src/swiftui/swiftuiMain.ts
+++ b/packages/backend/src/swiftui/swiftuiMain.ts
@@ -3,7 +3,11 @@ import { stringToClassName, sliceNum } from "../common/numToAutoFixed";
 import { SwiftuiTextBuilder } from "./swiftuiTextBuilder";
 import { SwiftuiDefaultBuilder } from "./swiftuiDefaultBuilder";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
+<<<<<<< HEAD
 import { PluginSettings } from "types";
+=======
+import { addWarning } from "../common/commonConversionWarnings";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 let localSettings: PluginSettings;
 let previousExecutionCache: string[];
@@ -84,6 +88,9 @@ const swiftuiWidgetGenerator = (
         break;
       case "TEXT":
         comp.push(swiftuiText(node));
+        break;
+      case "VECTOR":
+        addWarning("VectorNodes are not supported in SwiftUI");
         break;
       default:
         break;

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -5,13 +5,8 @@ import {
   nearestOpacity,
   nearestValue,
 } from "../conversionTables";
-<<<<<<< HEAD
 import { TailwindColorType } from "types";
-=======
 import { addWarning } from "../../common/commonConversionWarnings";
-
-type Kind = "text" | "bg" | "border" | "solid";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 /**
  * Get a tailwind color value object

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -5,7 +5,13 @@ import {
   nearestOpacity,
   nearestValue,
 } from "../conversionTables";
+<<<<<<< HEAD
 import { TailwindColorType } from "types";
+=======
+import { addWarning } from "../../common/commonConversionWarnings";
+
+type Kind = "text" | "bg" | "border" | "solid";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 /**
  * Get a tailwind color value object
@@ -89,6 +95,10 @@ export const tailwindGradientFromFills = (
   if (fill?.type === "GRADIENT_LINEAR") {
     return tailwindGradient(fill);
   }
+
+  addWarning(
+    "Gradients are not fully supported in Tailwind except for Linear Gradients.",
+  );
 
   return "";
 };

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -5,11 +5,8 @@ import { TailwindTextBuilder } from "./tailwindTextBuilder";
 import { TailwindDefaultBuilder } from "./tailwindDefaultBuilder";
 import { tailwindAutoLayoutProps } from "./builderImpl/tailwindAutoLayout";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-<<<<<<< HEAD
 import { PluginSettings } from "types";
-=======
 import { addWarning } from "../common/commonConversionWarnings";
->>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 export let localTailwindSettings: PluginSettings;
 

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -5,7 +5,11 @@ import { TailwindTextBuilder } from "./tailwindTextBuilder";
 import { TailwindDefaultBuilder } from "./tailwindDefaultBuilder";
 import { tailwindAutoLayoutProps } from "./builderImpl/tailwindAutoLayout";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
+<<<<<<< HEAD
 import { PluginSettings } from "types";
+=======
+import { addWarning } from "../common/commonConversionWarnings";
+>>>>>>> 4f01feb (Added a method for recording and displaying warnings when doing conversions.)
 
 export let localTailwindSettings: PluginSettings;
 
@@ -63,7 +67,9 @@ const tailwindWidgetGenerator = (
       case "SECTION":
         comp += tailwindSection(node, isJsx);
         break;
-      // case "VECTOR":
+      case "VECTOR":
+        addWarning("VectorNodes are not supported in Tailwind");
+        break;
       //   comp += htmlAsset(node, isJsx);
     }
   });
@@ -232,6 +238,7 @@ export const tailwindContainer = (
     let tag = "div";
     let src = "";
     if (retrieveTopFill(node.fills)?.type === "IMAGE") {
+      addWarning("Image fills are replaced with placeholders");
       if (!("children" in node) || node.children.length === 0) {
         tag = "img";
         src = ` src="https://via.placeholder.com/${node.width.toFixed(

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -8,12 +8,13 @@ import {
   LinearGradientConversion,
   PluginSettings,
   SolidColorConversion,
+  Warning,
 } from "types";
 
 type PluginUIProps = {
   code: string;
   htmlPreview: HTMLPreview;
-  warnings: string[];
+  warnings: Warning[];
   emptySelection: boolean;
   selectedFramework: FrameworkTypes;
   setSelectedFramework: (framework: FrameworkTypes) => void;

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -66,12 +66,17 @@ export const PluginUI = (props: PluginUIProps) => {
             />
           )}
           {warnings.length > 0 && (
-            <div className="flex flex-col bg-red-700 text-white p-4 w-full">
-              <h3 className="text-lg">Warnings:</h3>
-              <ul className="list-disc list-inside">
+            <div className="flex flex-col bg-yellow-400 text-black p-4 w-full">
+              <div className="flex flex-row gap-1">
+                <div style={{ transform: "translate(2px, 2px) scale(80%)" }}>
+                  <WarningIcon />
+                </div>
+                <h3 className="text-lg font-bold">Warnings:</h3>
+              </div>
+              <ul className="list-disc pl-6">
                 {warnings.map((message: string) => (
                   <li className="list-item">
-                    <em>{message}</em>
+                    <em className="italic">{message}</em>
                   </li>
                 ))}
               </ul>
@@ -584,5 +589,24 @@ const ExpandIcon = (props: { size: number }) => (
     viewBox="0 0 256 256"
   >
     <path d="M224,128a8,8,0,0,1-8,8H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM101.66,53.66,120,35.31V96a8,8,0,0,0,16,0V35.31l18.34,18.35a8,8,0,0,0,11.32-11.32l-32-32a8,8,0,0,0-11.32,0l-32,32a8,8,0,0,0,11.32,11.32Zm52.68,148.68L136,220.69V160a8,8,0,0,0-16,0v60.69l-18.34-18.35a8,8,0,0,0-11.32,11.32l32,32a8,8,0,0,0,11.32,0l32-32a8,8,0,0,0-11.32-11.32Z"></path>
+  </svg>
+);
+
+const WarningIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    className="lucide lucide-triangle-alert"
+  >
+    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+    <path d="M12 9v4" />
+    <path d="M12 17h.01" />
   </svg>
 );

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -66,7 +66,7 @@ export const PluginUI = (props: PluginUIProps) => {
             />
           )}
           {warnings.length > 0 && (
-            <div className="flex flex-col bg-yellow-400 text-black p-4 w-full">
+            <div className="flex flex-col bg-yellow-400 text-black  dark:bg-yellow-500 dark:text-black p-4 w-full">
               <div className="flex flex-row gap-1">
                 <div style={{ transform: "translate(2px, 2px) scale(80%)" }}>
                   <WarningIcon />

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -13,6 +13,7 @@ import {
 type PluginUIProps = {
   code: string;
   htmlPreview: HTMLPreview;
+  warnings: string[];
   emptySelection: boolean;
   selectedFramework: FrameworkTypes;
   setSelectedFramework: (framework: FrameworkTypes) => void;
@@ -22,13 +23,17 @@ type PluginUIProps = {
   gradients: LinearGradientConversion[];
 };
 
+const frameworks: FrameworkTypes[] = ["HTML", "Tailwind", "Flutter", "SwiftUI"];
+
 export const PluginUI = (props: PluginUIProps) => {
   const [isResponsiveExpanded, setIsResponsiveExpanded] = useState(false);
+
+  const warnings = props.warnings ?? [];
 
   return (
     <div className="flex flex-col h-full dark:text-white">
       <div className="p-2 grid grid-cols-4 sm:grid-cols-2 md:grid-cols-4 gap-1">
-        {["HTML", "Tailwind", "Flutter", "SwiftUI"].map((tab) => (
+        {frameworks.map((tab) => (
           <button
             key={`tab ${tab}`}
             className={`w-full p-1 text-sm ${
@@ -59,6 +64,18 @@ export const PluginUI = (props: PluginUIProps) => {
               isResponsiveExpanded={isResponsiveExpanded}
               setIsResponsiveExpanded={setIsResponsiveExpanded}
             />
+          )}
+          {warnings.length > 0 && (
+            <div className="flex flex-col bg-red-700 text-white p-4 w-full">
+              <h3 className="text-lg">Warnings:</h3>
+              <ul className="list-disc list-inside">
+                {warnings.map((message: string) => (
+                  <li className="list-item">
+                    <em>{message}</em>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
           <CodePanel
             code={props.code}
@@ -206,7 +223,8 @@ export const CodePanel = (props: {
   settings: PluginSettings | null;
   onPreferenceChanged: (key: string, value: boolean | string) => void;
 }) => {
-  const emptySelection = false;
+  const emptyCodeMessage = "// No layer is selected.";
+  const isEmpty = props.code === "";
   const [isPressed, setIsPressed] = useState(false);
   const [syntaxHovered, setSyntaxHovered] = useState(false);
 
@@ -220,25 +238,18 @@ export const CodePanel = (props: {
   const handleButtonHover = () => setSyntaxHovered(true);
   const handleButtonLeave = () => setSyntaxHovered(false);
 
-  if (emptySelection) {
-    return (
-      <div className="flex flex-col space-y-2 m-auto items-center justify-center p-4 {sectionStyle}">
-        <p className="text-lg font-bold">Nothing is selected</p>
-        <p className="text-xs">Try selecting a layer, any layer</p>
-      </div>
-    );
-  } else {
-    const selectableSettingsFiltered = selectPreferenceOptions.filter(
-      (preference) =>
-        preference.includedLanguages?.includes(props.selectedFramework),
-    );
+  const selectableSettingsFiltered = selectPreferenceOptions.filter(
+    (preference) =>
+      preference.includedLanguages?.includes(props.selectedFramework),
+  );
 
-    return (
-      <div className="w-full flex flex-col gap-2 mt-2">
-        <div className="flex items-center justify-between w-full">
-          <p className="text-lg font-medium text-center dark:text-white rounded-lg">
-            Code
-          </p>
+  return (
+    <div className="w-full flex flex-col gap-2 mt-2">
+      <div className="flex items-center justify-between w-full">
+        <p className="text-lg font-medium text-center dark:text-white rounded-lg">
+          Code
+        </p>
+        {isEmpty === false && (
           <button
             className={`px-4 py-1 text-sm font-semibold border border-green-500 rounded-md shadow-sm hover:bg-green-500 dark:hover:bg-green-600 hover:text-white hover:border-transparent transition-all duration-300 ${
               isPressed
@@ -251,8 +262,9 @@ export const CodePanel = (props: {
           >
             Copy
           </button>
-        </div>
-
+        )}
+      </div>
+      {isEmpty === false && (
         <div className="flex gap-2 justify-center flex-col p-2 dark:bg-black dark:bg-opacity-25 bg-neutral-100 ring-1 ring-neutral-200 dark:ring-neutral-700 rounded-lg text-sm">
           <div className="flex gap-2 items-center flex-wrap">
             {preferenceOptions
@@ -285,7 +297,7 @@ export const CodePanel = (props: {
                   <>
                     {/* <span className="min-w-[60px] font-medium">
                       {preference.label}
-                    </span> */}
+                      </span> */}
                     {preference.options.map((option) => (
                       <SelectableToggle
                         key={option.label}
@@ -311,32 +323,32 @@ export const CodePanel = (props: {
             </>
           )}
         </div>
+      )}
 
-        <div
-          className={`rounded-lg ring-green-600 transition-all duratio overflow-clip ${
-            syntaxHovered ? "ring-2" : "ring-0"
-          }`}
+      <div
+        className={`rounded-lg ring-green-600 transition-all duratio overflow-clip ${
+          syntaxHovered ? "ring-2" : "ring-0"
+        }`}
+      >
+        <SyntaxHighlighter
+          language="dart"
+          style={theme}
+          customStyle={{
+            fontSize: 12,
+            borderRadius: 8,
+            marginTop: 0,
+            marginBottom: 0,
+            backgroundColor: syntaxHovered ? "#1E2B1A" : "#1B1B1B",
+            transitionProperty: "all",
+            transitionTimingFunction: "ease",
+            transitionDuration: "0.2s",
+          }}
         >
-          <SyntaxHighlighter
-            language="dart"
-            style={theme}
-            customStyle={{
-              fontSize: 12,
-              borderRadius: 8,
-              marginTop: 0,
-              marginBottom: 0,
-              backgroundColor: syntaxHovered ? "#1E2B1A" : "#1B1B1B",
-              transitionProperty: "all",
-              transitionTimingFunction: "ease",
-              transitionDuration: "0.2s",
-            }}
-          >
-            {props.code}
-          </SyntaxHighlighter>
-        </div>
+          {props.code || emptyCodeMessage}
+        </SyntaxHighlighter>
       </div>
-    );
-  }
+    </div>
+  );
 };
 
 export const ColorsPanel = (props: {

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -15,7 +15,6 @@ type PluginUIProps = {
   code: string;
   htmlPreview: HTMLPreview;
   warnings: Warning[];
-  emptySelection: boolean;
   selectedFramework: FrameworkTypes;
   setSelectedFramework: (framework: FrameworkTypes) => void;
   settings: PluginSettings | null;
@@ -28,6 +27,7 @@ const frameworks: FrameworkTypes[] = ["HTML", "Tailwind", "Flutter", "SwiftUI"];
 
 export const PluginUI = (props: PluginUIProps) => {
   const [isResponsiveExpanded, setIsResponsiveExpanded] = useState(false);
+  const isEmpty = props.code === "";
 
   const warnings = props.warnings ?? [];
 
@@ -59,7 +59,7 @@ export const PluginUI = (props: PluginUIProps) => {
       ></div>
       <div className="flex flex-col h-full overflow-y-auto">
         <div className="flex flex-col items-center px-4 py-2 gap-2 dark:bg-transparent">
-          {props.htmlPreview && (
+          {isEmpty === false && props.htmlPreview && (
             <Preview
               htmlPreview={props.htmlPreview}
               isResponsiveExpanded={isResponsiveExpanded}
@@ -229,7 +229,6 @@ export const CodePanel = (props: {
   settings: PluginSettings | null;
   onPreferenceChanged: (key: string, value: boolean | string) => void;
 }) => {
-  const emptyCodeMessage = "// No layer is selected.";
   const isEmpty = props.code === "";
   const [isPressed, setIsPressed] = useState(false);
   const [syntaxHovered, setSyntaxHovered] = useState(false);
@@ -336,22 +335,26 @@ export const CodePanel = (props: {
           syntaxHovered ? "ring-2" : "ring-0"
         }`}
       >
-        <SyntaxHighlighter
-          language="dart"
-          style={theme}
-          customStyle={{
-            fontSize: 12,
-            borderRadius: 8,
-            marginTop: 0,
-            marginBottom: 0,
-            backgroundColor: syntaxHovered ? "#1E2B1A" : "#1B1B1B",
-            transitionProperty: "all",
-            transitionTimingFunction: "ease",
-            transitionDuration: "0.2s",
-          }}
-        >
-          {props.code || emptyCodeMessage}
-        </SyntaxHighlighter>
+        {isEmpty ? (
+          <h3>No layer is selected. Please select a layer.</h3>
+        ) : (
+          <SyntaxHighlighter
+            language="dart"
+            style={theme}
+            customStyle={{
+              fontSize: 12,
+              borderRadius: 8,
+              marginTop: 0,
+              marginBottom: 0,
+              backgroundColor: syntaxHovered ? "#1E2B1A" : "#1B1B1B",
+              transitionProperty: "all",
+              transitionTimingFunction: "ease",
+              transitionDuration: "0.2s",
+            }}
+          >
+            {props.code}
+          </SyntaxHighlighter>
+        )}
       </div>
     </div>
   );

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -22,7 +22,11 @@ export interface ConversionData {
   htmlPreview: HTMLPreview;
   colors: SolidColorConversion[];
   gradients: LinearGradientConversion[];
+  warnings: Warning[];
 }
+
+export type Warning = string;
+export type Warnings = Set<Warning>;
 
 export interface Message {
   type: string;


### PR DESCRIPTION
I've added a global object in backend/common that allows you to track errors when doing the conversion from Figma nodes to code. 
The file exposes `warnings` (a `Set<string>`), `addWarning()`, and `clearWarnings()`
The warnings are passed on to the UI to display to the user.
The warnings are also logged to console using `console.warn()`

<img width="854" alt="Screenshot 2024-12-18 at 23 43 57" src="https://github.com/user-attachments/assets/93a49798-2e65-4b69-b245-08a4cef674dc" />

**Known issue:** Any warnings for HTML always appear because they are triggered by the HTML Preview.
**Known issue:** I added warnings for a few conversion issues I was aware of but I assume there are many more that are not annotated. 