### PR TITLE
Convert Vectors to SVG, take 2

### DIFF
--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -122,7 +122,7 @@ const codegenMode = async () => {
           },
           {
             title: `Text Styles`,
-            code: htmlCodeGenTextStyles(false),
+            code: htmlCodeGenTextStyles(userPluginSettings),
             language: "HTML",
           },
         ];
@@ -139,7 +139,7 @@ const codegenMode = async () => {
           },
           {
             title: `Text Styles`,
-            code: htmlCodeGenTextStyles(true),
+            code: htmlCodeGenTextStyles(userPluginSettings),
             language: "HTML",
           },
         ];

--- a/packages/backend/src/altNodes/altConversion.ts
+++ b/packages/backend/src/altNodes/altConversion.ts
@@ -1,4 +1,4 @@
-import { StyledTextSegmentSubset, ParentNode } from "types";
+import { StyledTextSegmentSubset, ParentNode, AltNode } from "types";
 import {
   overrideReadonlyProperty,
   assignParent,
@@ -98,7 +98,8 @@ export const cloneNode = <T extends BaseNode>(
   }
   assignParent(parent, cloned);
 
-  return cloned;
+  const altNode = { ...cloned, originalNode: node } as AltNode<T>;
+  return altNode;
 };
 
 // auto convert Frame to Rectangle when Frame has no Children

--- a/packages/backend/src/altNodes/altConversion.ts
+++ b/packages/backend/src/altNodes/altConversion.ts
@@ -1,15 +1,22 @@
 import { StyledTextSegmentSubset, ParentNode, AltNode } from "types";
 import {
-  overrideReadonlyProperty,
   assignParent,
   isNotEmpty,
   assignRectangleType,
   assignChildren,
+  isTypeOrGroupOfTypes,
 } from "./altNodeUtils";
-import { addWarning } from "../common/commonConversionWarnings";
 
 export let globalTextStyleSegments: Record<string, StyledTextSegmentSubset[]> =
   {};
+
+// List of types that can be flattened into SVG
+const canBeFlattened = isTypeOrGroupOfTypes([
+  "VECTOR",
+  "STAR",
+  "POLYGON",
+  "BOOLEAN_OPERATION",
+]);
 
 export const convertNodeToAltNode =
   (parent: ParentNode | null) =>
@@ -98,7 +105,11 @@ export const cloneNode = <T extends BaseNode>(
   }
   assignParent(parent, cloned);
 
-  const altNode = { ...cloned, originalNode: node } as AltNode<T>;
+  const altNode = {
+    ...cloned,
+    originalNode: node,
+    canBeFlattened: canBeFlattened(node),
+  } as AltNode<T>;
   return altNode;
 };
 

--- a/packages/backend/src/altNodes/altNodeUtils.ts
+++ b/packages/backend/src/altNodes/altNodeUtils.ts
@@ -1,3 +1,4 @@
+import { AltNode } from "types";
 import { curry } from "../common/curry";
 
 export const overrideReadonlyProperty = curry(
@@ -19,3 +20,44 @@ export function isNotEmpty<TValue>(
 ): value is TValue {
   return value !== null && value !== undefined;
 }
+
+export const isTypeOrGroupOfTypes = curry(
+  (matchTypes: NodeType[], node: SceneNode): boolean => {
+    if (node.visible === false || matchTypes.includes(node.type)) return true;
+
+    if ("children" in node) {
+      for (let i = 0; i < node.children.length; i++) {
+        const childNode = node.children[i];
+        const result = isTypeOrGroupOfTypes(matchTypes, childNode);
+        if (result) continue;
+        // child is false
+        return false;
+      }
+      // all children are true
+      return true;
+    }
+
+    // not group or vector
+    return false;
+  },
+);
+
+export const renderNodeAsSVG = async (node: SceneNode) =>
+  await node.exportAsync({ format: "SVG_STRING" });
+
+export const renderAndAttachSVG = async (node: SceneNode) => {
+  const altNode = node as AltNode<typeof node>;
+  // const nodeName = `${node.type}:${node.id}`;
+  // console.log(altNode);
+  if (altNode.canBeFlattened) {
+    if (altNode.svg) {
+      // console.log(`SVG already rendered for ${nodeName}`);
+      return altNode;
+    }
+    // console.log(`${nodeName} can be flattened!`);
+    const svg = await renderNodeAsSVG(altNode.originalNode);
+    // console.log(`${svg}`);
+    altNode.svg = svg;
+  }
+  return altNode;
+};

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -9,7 +9,7 @@ import { clearWarnings, warnings } from "./common/commonConversionWarnings";
 import { PluginSettings } from "types";
 import { convertToCode } from "./common/retrieveUI/convertToCode";
 
-export const run = (settings: PluginSettings) => {
+export const run = async (settings: PluginSettings) => {
   clearWarnings();
   const { framework } = settings;
   const selection = figma.currentPage.selection;
@@ -23,8 +23,12 @@ export const run = (settings: PluginSettings) => {
     return;
   }
 
-  const code = convertToCode(convertedSelection, settings);
-  const htmlPreview = generateHTMLPreview(convertedSelection, settings, code);
+  const code = await convertToCode(convertedSelection, settings);
+  const htmlPreview = await generateHTMLPreview(
+    convertedSelection,
+    settings,
+    code,
+  );
   const colors = retrieveGenericSolidUIColors(framework);
   const gradients = retrieveGenericGradients(framework);
 

--- a/packages/backend/src/common/commonFormatAttributes.ts
+++ b/packages/backend/src/common/commonFormatAttributes.ts
@@ -17,8 +17,8 @@ export const formatStyleAttribute = (
   return ` style=${isJSX ? `{{${trimmedStyles}}}` : `"${trimmedStyles}"`}`;
 };
 
-export const formatLayerNameAttribute = (name: string) =>
-  name === "" ? "" : ` data-layer="${name}"`;
+export const formatDataAttribute = (label: string, value?: string) =>
+  ` data-${label}${value === undefined ? `` : `="${value}"`}`;
 
 export const formatClassAttribute = (
   classes: string[],

--- a/packages/backend/src/common/isVisible.ts
+++ b/packages/backend/src/common/isVisible.ts
@@ -1,1 +1,0 @@
-export const isVisible = (node: { visible: boolean }) => node.visible;

--- a/packages/backend/src/common/isVisible.ts
+++ b/packages/backend/src/common/isVisible.ts
@@ -1,0 +1,1 @@
+export const isVisible = (node: { visible: boolean }) => node.visible;

--- a/packages/backend/src/common/nodeVisibility.ts
+++ b/packages/backend/src/common/nodeVisibility.ts
@@ -1,0 +1,4 @@
+type VisibilityMixin = { visible: boolean };
+const isVisible = (node: VisibilityMixin) => node.visible;
+export const getVisibleNodes = (nodes: readonly SceneNode[]) =>
+  nodes.filter(isVisible);

--- a/packages/backend/src/common/retrieveFill.ts
+++ b/packages/backend/src/common/retrieveFill.ts
@@ -2,7 +2,7 @@
  * Retrieve the first visible color that is being used by the layer, in case there are more than one.
  */
 export const retrieveTopFill = (
-  fills: ReadonlyArray<Paint> | PluginAPI["mixed"],
+  fills: ReadonlyArray<Paint> | PluginAPI["mixed"] | undefined,
 ): Paint | undefined => {
   if (fills && fills !== figma.mixed && fills.length > 0) {
     // on Figma, the top layer is always at the last position

--- a/packages/backend/src/common/retrieveUI/convertToCode.ts
+++ b/packages/backend/src/common/retrieveUI/convertToCode.ts
@@ -4,16 +4,19 @@ import { htmlMain } from "../../html/htmlMain";
 import { swiftuiMain } from "../../swiftui/swiftuiMain";
 import { tailwindMain } from "../../tailwind/tailwindMain";
 
-export const convertToCode = (nodes: SceneNode[], settings: PluginSettings) => {
+export const convertToCode = async (
+  nodes: SceneNode[],
+  settings: PluginSettings,
+) => {
   switch (settings.framework) {
     case "Tailwind":
-      return tailwindMain(nodes, settings);
+      return await tailwindMain(nodes, settings);
     case "Flutter":
-      return flutterMain(nodes, settings);
+      return await flutterMain(nodes, settings);
     case "SwiftUI":
-      return swiftuiMain(nodes, settings);
+      return await swiftuiMain(nodes, settings);
     case "HTML":
     default:
-      return htmlMain(nodes, settings);
+      return await htmlMain(nodes, settings);
   }
 };

--- a/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
+++ b/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
@@ -1,3 +1,4 @@
+import { PluginSettings } from "types";
 import { formatMultipleJSXArray } from "../../common/parseJSX";
 
 const getFlexDirection = (node: InferredAutoLayoutResult): string =>
@@ -47,7 +48,7 @@ const getFlex = (
 export const htmlAutoLayoutProps = (
   node: SceneNode,
   autoLayout: InferredAutoLayoutResult,
-  isJsx: boolean,
+  settings: PluginSettings,
 ): string[] =>
   formatMultipleJSXArray(
     {
@@ -57,5 +58,5 @@ export const htmlAutoLayoutProps = (
       gap: getGap(autoLayout),
       display: getFlex(node, autoLayout),
     },
-    isJsx,
+    settings.jsx,
   );

--- a/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
+++ b/packages/backend/src/html/builderImpl/htmlAutoLayout.ts
@@ -1,4 +1,4 @@
-import { PluginSettings } from "types";
+import { HTMLSettings, PluginSettings } from "types";
 import { formatMultipleJSXArray } from "../../common/parseJSX";
 
 const getFlexDirection = (node: InferredAutoLayoutResult): string =>
@@ -48,7 +48,7 @@ const getFlex = (
 export const htmlAutoLayoutProps = (
   node: SceneNode,
   autoLayout: InferredAutoLayoutResult,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): string[] =>
   formatMultipleJSXArray(
     {

--- a/packages/backend/src/html/builderImpl/htmlBorderRadius.ts
+++ b/packages/backend/src/html/builderImpl/htmlBorderRadius.ts
@@ -40,29 +40,7 @@ export const htmlBorderRadius = (node: SceneNode, isJsx: boolean): string[] => {
     node.children.length > 0 &&
     node.clipsContent === true
   ) {
-    // if (
-    //   node.children.some(
-    //     (child) =>
-    //       "layoutPositioning" in child && node.layoutPositioning === "AUTO"
-    //   )
-    // ) {
-    //   if (singleCorner) {
-    //     comp.push(
-    //       formatWithJSX(
-    //         "clip-path",
-    //         isJsx,
-    //         `inset(0px round ${singleCorner}px)`
-    //       )
-    //     );
-    //   } else if (cornerValues.filter((d) => d > 0).length > 0) {
-    //     const insetValues = cornerValues.map((value) => `${value}px`).join(" ");
-    //     comp.push(
-    //       formatWithJSX("clip-path", isJsx, `inset(0px round ${insetValues})`)
-    //     );
-    //   }
-    // } else {
     comp.push(formatWithJSX("overflow", isJsx, "hidden"));
-    // }
   }
 
   return comp;

--- a/packages/backend/src/html/builderImpl/htmlColor.ts
+++ b/packages/backend/src/html/builderImpl/htmlColor.ts
@@ -3,7 +3,7 @@ import { retrieveTopFill } from "../../common/retrieveFill";
 
 // retrieve the SOLID color on HTML
 export const htmlColorFromFills = (
-  fills: ReadonlyArray<Paint> | PluginAPI["mixed"],
+  fills: ReadonlyArray<Paint> | PluginAPI["mixed"] | undefined,
 ): string => {
   // kind can be text, bg, border...
   // [when testing] fills can be undefined

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -24,7 +24,7 @@ import {
   formatDataAttribute,
   formatStyleAttribute,
 } from "../common/commonFormatAttributes";
-import { PluginSettings } from "types";
+import { HTMLSettings, PluginSettings } from "types";
 
 export class HtmlDefaultBuilder {
   styles: Array<string>;
@@ -33,7 +33,7 @@ export class HtmlDefaultBuilder {
   visible: boolean;
   name: string;
 
-  constructor(node: SceneNode, settings: PluginSettings) {
+  constructor(node: SceneNode, settings: HTMLSettings) {
     this.isJSX = settings.jsx;
     this.styles = [];
     this.data = [];

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -21,12 +21,13 @@ import { sliceNum, stringToClassName } from "../common/numToAutoFixed";
 import { commonStroke } from "../common/commonStroke";
 import {
   formatClassAttribute,
-  formatLayerNameAttribute,
+  formatDataAttribute,
   formatStyleAttribute,
 } from "../common/commonFormatAttributes";
 
 export class HtmlDefaultBuilder {
   styles: Array<string>;
+  data: Array<string>;
   isJSX: boolean;
   visible: boolean;
   name: string;
@@ -34,6 +35,7 @@ export class HtmlDefaultBuilder {
   constructor(node: SceneNode, showLayerNames: boolean, optIsJSX: boolean) {
     this.isJSX = optIsJSX;
     this.styles = [];
+    this.data = [];
     this.visible = node.visible;
     this.name = showLayerNames ? node.name : "";
   }
@@ -286,17 +288,28 @@ export class HtmlDefaultBuilder {
     }
   }
 
+  addData(label: string, value?: string): this {
+    const attribute = formatDataAttribute(label, value);
+    this.data.push(attribute);
+    return this;
+  }
+
   build(additionalStyle: Array<string> = []): string {
     this.addStyles(...additionalStyle);
 
-    const layerNameAttribute = formatLayerNameAttribute(this.name);
-    const layerNameClass = stringToClassName(this.name);
-    const classAttribute = formatClassAttribute(
-      layerNameClass === "" ? [] : [layerNameClass],
-      this.isJSX,
-    );
+    let classAttribute = "";
+    if (this.name) {
+      this.addData("layer", this.name);
+      const layerNameClass = stringToClassName(this.name);
+      classAttribute = formatClassAttribute(
+        layerNameClass === "" ? [] : [layerNameClass],
+        this.isJSX,
+      );
+    }
+
+    const dataAttributes = this.data.join("");
     const styleAttribute = formatStyleAttribute(this.styles, this.isJSX);
 
-    return `${layerNameAttribute}${classAttribute}${styleAttribute}`;
+    return `${dataAttributes}${classAttribute}${styleAttribute}`;
   }
 }

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -24,7 +24,7 @@ import {
   formatDataAttribute,
   formatStyleAttribute,
 } from "../common/commonFormatAttributes";
-import { HTMLSettings, PluginSettings } from "types";
+import { HTMLSettings } from "types";
 
 export class HtmlDefaultBuilder {
   styles: Array<string>;

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -24,6 +24,7 @@ import {
   formatDataAttribute,
   formatStyleAttribute,
 } from "../common/commonFormatAttributes";
+import { PluginSettings } from "types";
 
 export class HtmlDefaultBuilder {
   styles: Array<string>;
@@ -32,12 +33,12 @@ export class HtmlDefaultBuilder {
   visible: boolean;
   name: string;
 
-  constructor(node: SceneNode, showLayerNames: boolean, optIsJSX: boolean) {
-    this.isJSX = optIsJSX;
+  constructor(node: SceneNode, settings: PluginSettings) {
+    this.isJSX = settings.jsx;
     this.styles = [];
     this.data = [];
     this.visible = node.visible;
-    this.name = showLayerNames ? node.name : "";
+    this.name = settings.showLayerNames ? node.name : "";
   }
 
   commonPositionStyles(

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -6,7 +6,7 @@ import { htmlAutoLayoutProps } from "./builderImpl/htmlAutoLayout";
 import { formatWithJSX } from "../common/parseJSX";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
 import { addWarning } from "../common/commonConversionWarnings";
-import { PluginSettings, HTMLPreview, AltNode } from "types";
+import { PluginSettings, HTMLPreview, AltNode, HTMLSettings } from "types";
 import { renderAndAttachSVG } from "../altNodes/altNodeUtils";
 import { getVisibleNodes } from "../common/nodeVisibility";
 
@@ -64,7 +64,7 @@ export const generateHTMLPreview = async (
 // todo lint idea: replace BorderRadius.only(topleft: 8, topRight: 8) with BorderRadius.horizontal(8)
 const htmlWidgetGenerator = async (
   sceneNode: ReadonlyArray<SceneNode>,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): Promise<string> => {
   // filter non visible nodes. This is necessary at this step because conversion already happened.
   const promiseOfConvertedCode = getVisibleNodes(sceneNode).map(
@@ -74,7 +74,7 @@ const htmlWidgetGenerator = async (
   return code;
 };
 
-const convertNode = (settings: PluginSettings) => async (node: SceneNode) => {
+const convertNode = (settings: HTMLSettings) => async (node: SceneNode) => {
   const altNode = await renderAndAttachSVG(node);
   if (altNode.svg) return htmlWrapSVG(altNode, settings);
 
@@ -105,7 +105,7 @@ const convertNode = (settings: PluginSettings) => async (node: SceneNode) => {
 
 const htmlWrapSVG = (
   node: AltNode<SceneNode>,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): string => {
   if (node.svg === "") return "";
   const builder = new HtmlDefaultBuilder(node, settings)
@@ -117,7 +117,7 @@ const htmlWrapSVG = (
 
 const htmlGroup = async (
   node: GroupNode,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): Promise<string> => {
   // ignore the view when size is zero or less
   // while technically it shouldn't get less than 0, due to rounding errors,
@@ -145,7 +145,7 @@ const htmlGroup = async (
 };
 
 // this was split from htmlText to help the UI part, where the style is needed (without <p></p>).
-const htmlText = (node: TextNode, settings: PluginSettings): string => {
+const htmlText = (node: TextNode, settings: HTMLSettings): string => {
   let layoutBuilder = new HtmlTextBuilder(node, settings)
     .commonPositionStyles(node, settings.optimizeLayout)
     .textAlign(node);
@@ -188,7 +188,7 @@ const htmlText = (node: TextNode, settings: PluginSettings): string => {
 
 const htmlFrame = async (
   node: SceneNode & BaseFrameMixin,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): Promise<string> => {
   const childrenStr = await htmlWidgetGenerator(
     commonSortChildrenWhenInferredAutoLayout(node, settings.optimizeLayout),
@@ -214,7 +214,7 @@ const htmlFrame = async (
   }
 };
 
-const htmlAsset = (node: SceneNode, settings: PluginSettings): string => {
+const htmlAsset = (node: SceneNode, settings: HTMLSettings): string => {
   if (!("opacity" in node) || !("layoutAlign" in node) || !("fills" in node)) {
     return "";
   }
@@ -251,7 +251,7 @@ const htmlContainer = (
     MinimalBlendMixin,
   children: string,
   additionalStyles: string[] = [],
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): string => {
   // ignore the view when size is zero or less
   // while technically it shouldn't get less than 0, due to rounding errors,
@@ -303,7 +303,7 @@ const htmlContainer = (
 
 const htmlSection = async (
   node: SectionNode,
-  settings: PluginSettings,
+  settings: HTMLSettings,
 ): Promise<string> => {
   const childrenStr = await htmlWidgetGenerator(node.children, settings);
   const builder = new HtmlDefaultBuilder(node, settings)
@@ -318,7 +318,7 @@ const htmlSection = async (
   }
 };
 
-const htmlLine = (node: LineNode, settings: PluginSettings): string => {
+const htmlLine = (node: LineNode, settings: HTMLSettings): string => {
   const builder = new HtmlDefaultBuilder(node, settings)
     .commonPositionStyles(node, settings.optimizeLayout)
     .commonShapeStyles(node);
@@ -326,7 +326,7 @@ const htmlLine = (node: LineNode, settings: PluginSettings): string => {
   return `\n<div${builder.build()}></div>`;
 };
 
-export const htmlCodeGenTextStyles = (settings: PluginSettings) => {
+export const htmlCodeGenTextStyles = (settings: HTMLSettings) => {
   const result = previousExecutionCache
     .map(
       (style) =>

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -110,7 +110,7 @@ const htmlWrapSVG = (
   if (node.svg === "") return "";
   const builder = new HtmlDefaultBuilder(node, settings)
     .addData("svg-wrapper")
-    .position(node, settings.optimizeLayout);
+    .position();
 
   return `\n<div${builder.build()}>\n${node.svg ?? ""}</div>`;
 };
@@ -128,10 +128,7 @@ const htmlGroup = async (
   }
 
   // this needs to be called after CustomNode because widthHeight depends on it
-  const builder = new HtmlDefaultBuilder(node, settings).commonPositionStyles(
-    node,
-    settings.optimizeLayout,
-  );
+  const builder = new HtmlDefaultBuilder(node, settings).commonPositionStyles();
 
   if (builder.styles) {
     const attr = builder.build();
@@ -147,8 +144,8 @@ const htmlGroup = async (
 // this was split from htmlText to help the UI part, where the style is needed (without <p></p>).
 const htmlText = (node: TextNode, settings: HTMLSettings): string => {
   let layoutBuilder = new HtmlTextBuilder(node, settings)
-    .commonPositionStyles(node, settings.optimizeLayout)
-    .textAlign(node);
+    .commonPositionStyles()
+    .textAlign();
 
   const styledHtml = layoutBuilder.getTextSegments(node.id);
   previousExecutionCache.push(...styledHtml);
@@ -220,8 +217,8 @@ const htmlAsset = (node: SceneNode, settings: HTMLSettings): string => {
   }
 
   const builder = new HtmlDefaultBuilder(node, settings)
-    .commonPositionStyles(node, settings.optimizeLayout)
-    .commonShapeStyles(node);
+    .commonPositionStyles()
+    .commonShapeStyles();
 
   let tag = "div";
   let src = "";
@@ -261,8 +258,8 @@ const htmlContainer = (
   }
 
   const builder = new HtmlDefaultBuilder(node, settings)
-    .commonPositionStyles(node, settings.optimizeLayout)
-    .commonShapeStyles(node);
+    .commonPositionStyles()
+    .commonShapeStyles();
 
   if (builder.styles || additionalStyles) {
     let tag = "div";
@@ -307,8 +304,8 @@ const htmlSection = async (
 ): Promise<string> => {
   const childrenStr = await htmlWidgetGenerator(node.children, settings);
   const builder = new HtmlDefaultBuilder(node, settings)
-    .size(node, settings.optimizeLayout)
-    .position(node, settings.optimizeLayout)
+    .size()
+    .position()
     .applyFillsToStyle(node.fills, "background");
 
   if (childrenStr) {
@@ -320,8 +317,8 @@ const htmlSection = async (
 
 const htmlLine = (node: LineNode, settings: HTMLSettings): string => {
   const builder = new HtmlDefaultBuilder(node, settings)
-    .commonPositionStyles(node, settings.optimizeLayout)
-    .commonShapeStyles(node);
+    .commonPositionStyles()
+    .commonShapeStyles();
 
   return `\n<div${builder.build()}></div>`;
 };

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -7,8 +7,8 @@ import { formatWithJSX } from "../common/parseJSX";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
 import { addWarning } from "../common/commonConversionWarnings";
 import { PluginSettings, HTMLPreview, AltNode } from "types";
-import { isVisible } from "../common/isVisible";
 import { renderAndAttachSVG } from "../altNodes/altNodeUtils";
+import { getVisibleNodes } from "../common/nodeVisibility";
 
 let showLayerNames = false;
 
@@ -72,9 +72,9 @@ const htmlWidgetGenerator = async (
   isJsx: boolean,
 ): Promise<string> => {
   // filter non visible nodes. This is necessary at this step because conversion already happened.
-  const promiseOfConvertedCode = sceneNode
-    .filter(isVisible)
-    .map(convertNode(isJsx));
+  const promiseOfConvertedCode = getVisibleNodes(sceneNode).map(
+    convertNode(isJsx),
+  );
   const code = (await Promise.all(promiseOfConvertedCode)).join("");
   return code;
 };

--- a/packages/backend/src/html/htmlTextBuilder.ts
+++ b/packages/backend/src/html/htmlTextBuilder.ts
@@ -116,7 +116,8 @@ export class HtmlTextBuilder extends HtmlDefaultBuilder {
     return "";
   }
 
-  textAlign(node: TextNode): this {
+  textAlign(): this {
+    const node = this.node as TextNode;
     // if alignHorizontal is LEFT, don't do anything because that is native
 
     // only undefined in testing

--- a/packages/backend/src/html/htmlTextBuilder.ts
+++ b/packages/backend/src/html/htmlTextBuilder.ts
@@ -6,10 +6,10 @@ import {
   commonLetterSpacing,
   commonLineHeight,
 } from "../common/commonTextHeightSpacing";
-import { PluginSettings } from "types";
+import { HTMLSettings } from "types";
 
 export class HtmlTextBuilder extends HtmlDefaultBuilder {
-  constructor(node: TextNode, settings: PluginSettings) {
+  constructor(node: TextNode, settings: HTMLSettings) {
     super(node, settings);
   }
 

--- a/packages/backend/src/html/htmlTextBuilder.ts
+++ b/packages/backend/src/html/htmlTextBuilder.ts
@@ -6,15 +6,14 @@ import {
   commonLetterSpacing,
   commonLineHeight,
 } from "../common/commonTextHeightSpacing";
+import { PluginSettings } from "types";
 
 export class HtmlTextBuilder extends HtmlDefaultBuilder {
-  constructor(node: TextNode, showLayerNames: boolean, optIsJSX: boolean) {
-    super(node, showLayerNames, optIsJSX);
+  constructor(node: TextNode, settings: PluginSettings) {
+    super(node, settings);
   }
 
-  getTextSegments(
-    id: string,
-  ): {
+  getTextSegments(id: string): {
     style: string;
     text: string;
     openTypeFeatures: { [key: string]: boolean };

--- a/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
@@ -22,8 +22,8 @@ import {
 } from "../common/commonPosition";
 import { pxToBlur } from "./conversionTables";
 import {
+  formatDataAttribute,
   getClassLabel,
-  formatStyleAttribute,
 } from "../common/commonFormatAttributes";
 import { TailwindColorType } from "types";
 
@@ -33,6 +33,7 @@ const dropEmptyStrings = (strings: string[]) => strings.filter(isNotEmpty);
 export class TailwindDefaultBuilder {
   attributes: string[] = [];
   style: string;
+  data: string[];
   styleSeparator: string = "";
   isJSX: boolean;
   visible: boolean;
@@ -42,6 +43,7 @@ export class TailwindDefaultBuilder {
     this.isJSX = optIsJSX;
     this.styleSeparator = this.isJSX ? "," : ";";
     this.style = "";
+    this.data = [];
     this.visible = node.visible;
     this.name = showLayerNames ? node.name : "";
 
@@ -239,13 +241,21 @@ export class TailwindDefaultBuilder {
     }
   }
 
+  addData(label: string, value?: string): this {
+    const attribute = formatDataAttribute(label, value);
+    this.data.push(attribute);
+    return this;
+  }
+
   build(additionalAttr = ""): string {
     this.addAttributes(additionalAttr);
 
     if (this.name !== "") {
       this.prependAttributes(stringToClassName(this.name));
     }
-    const layerName = this.name ? ` data-layer="${this.name}"` : "";
+    if (this.name) {
+      this.addData("layer", this.name);
+    }
 
     const classLabel = getClassLabel(this.isJSX);
     const classNames =
@@ -253,12 +263,14 @@ export class TailwindDefaultBuilder {
         ? ` ${classLabel}="${this.attributes.join(" ")}"`
         : "";
     const styles = this.style.length > 0 ? ` style="${this.style}"` : "";
+    const dataAttributes = this.data.join("");
 
-    return `${layerName}${classNames}${styles}`;
+    return `${dataAttributes}${classNames}${styles}`;
   }
 
   reset(): void {
     this.attributes = [];
+    this.data = [];
     this.style = "";
   }
 }

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -80,13 +80,9 @@ const tailwindWrapSVG = (
   settings: TailwindSettings,
 ): string => {
   if (node.svg === "") return "";
-  const builder = new TailwindDefaultBuilder(
-    node,
-    settings.showLayerNames,
-    settings.jsx,
-  )
+  const builder = new TailwindDefaultBuilder(node, settings)
     .addData("svg-wrapper")
-    .position(node, settings.optimizeLayout);
+    .position();
 
   return `\n<div${builder.build()}>\n${node.svg ?? ""}</div>`;
 };
@@ -101,14 +97,10 @@ const tailwindGroup = async (node: GroupNode, settings: TailwindSettings) => {
   }
 
   // this needs to be called after CustomNode because widthHeight depends on it
-  const builder = new TailwindDefaultBuilder(
-    node,
-    localTailwindSettings.showLayerNames,
-    settings.jsx,
-  )
-    .blend(node)
-    .size(node, localTailwindSettings.optimizeLayout)
-    .position(node, localTailwindSettings.optimizeLayout);
+  const builder = new TailwindDefaultBuilder(node, settings)
+    .blend()
+    .size()
+    .position();
 
   if (builder.attributes || builder.style) {
     const attr = builder.build("");
@@ -125,13 +117,9 @@ export const tailwindText = (
   node: TextNode,
   settings: TailwindSettings,
 ): string => {
-  let layoutBuilder = new TailwindTextBuilder(
-    node,
-    localTailwindSettings.showLayerNames,
-    settings.jsx,
-  )
-    .commonPositionStyles(node, localTailwindSettings.optimizeLayout)
-    .textAlign(node);
+  let layoutBuilder = new TailwindTextBuilder(node, settings)
+    .commonPositionStyles()
+    .textAlign();
 
   const styledHtml = layoutBuilder.getTextSegments(node.id);
   previousExecutionCache.push(...styledHtml);
@@ -232,13 +220,9 @@ export const tailwindContainer = (
     return children;
   }
 
-  let builder = new TailwindDefaultBuilder(
-    node,
-    localTailwindSettings.showLayerNames,
-    settings.jsx,
-  )
-    .commonPositionStyles(node, localTailwindSettings.optimizeLayout)
-    .commonShapeStyles(node);
+  let builder = new TailwindDefaultBuilder(node, settings)
+    .commonPositionStyles()
+    .commonShapeStyles();
 
   if (builder.attributes || additionalAttr) {
     const build = builder.build(additionalAttr);
@@ -278,13 +262,9 @@ export const tailwindLine = (
   node: LineNode,
   settings: TailwindSettings,
 ): string => {
-  const builder = new TailwindDefaultBuilder(
-    node,
-    localTailwindSettings.showLayerNames,
-    settings.jsx,
-  )
-    .commonPositionStyles(node, localTailwindSettings.optimizeLayout)
-    .commonShapeStyles(node);
+  const builder = new TailwindDefaultBuilder(node, settings)
+    .commonPositionStyles()
+    .commonShapeStyles();
 
   return `\n<div${builder.build()}></div>`;
 };
@@ -294,13 +274,9 @@ export const tailwindSection = async (
   settings: TailwindSettings,
 ): Promise<string> => {
   const childrenStr = await tailwindWidgetGenerator(node.children, settings);
-  const builder = new TailwindDefaultBuilder(
-    node,
-    localTailwindSettings.showLayerNames,
-    settings.jsx,
-  )
-    .size(node, localTailwindSettings.optimizeLayout)
-    .position(node, localTailwindSettings.optimizeLayout)
+  const builder = new TailwindDefaultBuilder(node, settings)
+    .size()
+    .position()
     .customColor(node.fills, "bg");
 
   if (childrenStr) {

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -4,10 +4,10 @@ import { TailwindTextBuilder } from "./tailwindTextBuilder";
 import { TailwindDefaultBuilder } from "./tailwindDefaultBuilder";
 import { tailwindAutoLayoutProps } from "./builderImpl/tailwindAutoLayout";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-import { AltNode, PluginSettings } from "types";
+import { PluginSettings } from "types";
 import { addWarning } from "../common/commonConversionWarnings";
 import { renderAndAttachSVG, renderNodeAsSVG } from "../altNodes/altNodeUtils";
-import { isVisible } from "../common/isVisible";
+import { getVisibleNodes } from "../common/nodeVisibility";
 
 export let localTailwindSettings: PluginSettings;
 
@@ -41,9 +41,9 @@ const tailwindWidgetGenerator = async (
   isJsx: boolean,
 ): Promise<string> => {
   // filter non visible nodes. This is necessary at this step because conversion already happened.
-  const promiseOfConvertedCode = sceneNode
-    .filter(isVisible)
-    .map(convertNode(isJsx));
+  const promiseOfConvertedCode = getVisibleNodes(sceneNode).map(
+    convertNode(isJsx),
+  );
   const code = (await Promise.all(promiseOfConvertedCode)).join("");
   return code;
 };

--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -170,9 +170,9 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
    * https://tailwindcss.com/docs/text-align/
    * example: text-justify
    */
-  textAlign(node: TextNode): this {
+  textAlign(): this {
     // if alignHorizontal is LEFT, don't do anything because that is native
-
+    const node = this.node as TextNode;
     // only undefined in testing
     if (node.textAlignHorizontal && node.textAlignHorizontal !== "LEFT") {
       // todo when node.textAutoResize === "WIDTH_AND_HEIGHT" and there is no \n in the text, this can be ignored.

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,12 +1,14 @@
 // Settings
 export type Framework = "Flutter" | "SwiftUI" | "HTML" | "Tailwind";
 
-export interface PluginSettings {
-  framework: Framework;
+export interface HTMLSettings {
   jsx: boolean;
-  inlineStyle: boolean;
   optimizeLayout: boolean;
   showLayerNames: boolean;
+}
+export interface PluginSettings extends HTMLSettings {
+  framework: Framework;
+  inlineStyle: boolean;
   responsiveRoot: boolean;
   flutterGenerationMode: string;
   swiftUIGenerationMode: string;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,22 +1,30 @@
 // Settings
 export type Framework = "Flutter" | "SwiftUI" | "HTML" | "Tailwind";
-
 export interface HTMLSettings {
   jsx: boolean;
   optimizeLayout: boolean;
   showLayerNames: boolean;
 }
-export interface PluginSettings extends HTMLSettings {
-  framework: Framework;
-  inlineStyle: boolean;
-  responsiveRoot: boolean;
-  flutterGenerationMode: string;
-  swiftUIGenerationMode: string;
+export interface TailwindSettings extends HTMLSettings {
   roundTailwindValues: boolean;
   roundTailwindColors: boolean;
   customTailwindColors: boolean;
 }
-
+export interface FlutterSettings {
+  flutterGenerationMode: string;
+}
+export interface SwiftUISettings {
+  swiftUIGenerationMode: string;
+}
+export interface PluginSettings
+  extends HTMLSettings,
+    TailwindSettings,
+    FlutterSettings,
+    SwiftUISettings {
+  framework: Framework;
+  inlineStyle: boolean;
+  responsiveRoot: boolean;
+}
 // Messaging
 export interface ConversionData {
   code: string;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -55,7 +55,10 @@ export type ErrorMessage = Message & {
 // Nodes
 export type ParentNode = BaseNode & ChildrenMixin;
 
-export type AltNode<T extends BaseNode> = T & { originalNode: T };
+export type AltNodeMetadata<T extends BaseNode> = {
+  originalNode: T;
+};
+export type AltNode<T extends BaseNode> = T & AltNodeMetadata<T>;
 
 // Styles & Conversions
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -55,6 +55,8 @@ export type ErrorMessage = Message & {
 // Nodes
 export type ParentNode = BaseNode & ChildrenMixin;
 
+export type AltNode<T extends BaseNode> = T & { originalNode: T };
+
 // Styles & Conversions
 
 export type LayoutMode =

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -57,6 +57,8 @@ export type ParentNode = BaseNode & ChildrenMixin;
 
 export type AltNodeMetadata<T extends BaseNode> = {
   originalNode: T;
+  canBeFlattened: boolean;
+  svg?: string;
 };
 export type AltNode<T extends BaseNode> = T & AltNodeMetadata<T>;
 


### PR DESCRIPTION
Hi @bernaferrari 

I've done another pass on this. There are probably a few things that should be fixed before merging but I wanted to show you. I'm interested in getting your feedback on this since you have a lot more experience with this than I do. 

Here's a summary...

1. the conversion to alt nodes adds a bit of metadata to the AltNode. 
  1. It checks whether the nodes can be flattened. We define some types to look for (e.g. "VECTOR") then we check the nodes and all the child nodes, grandchildren etc. If a node is made up entirely of flattenable nodes or groups that contain only flattenable nodes, it can be flattened. 
  2. It adds a reference to the original node that was converted. 
  3. There is a place to store the SVG string generated.
2. In the conversion to code for HTML and Tailwind, the nodes are checked to see if they can be compressed. If so, we use `exportAsync()` to flatten the node. It gets stored in the svg prop so it doesn't get run more than once. 
3. SVG gets wrapped in a div

Known issues:

- [ ] - There is no loading state for the asynchronous functions
- [x] - Seems like there are issues with positioning when there are multiple SVG groups  generated. The SVGs probably need to be wrapped in a `div` with `position: absolute`
- [x] - In the case that you have a bunch of vectors and down in the tree is a text field, exportAsync will be run more than once. Each vector or group that can be flattened will be but the entire thing can't be flattened as one. That seems like a reasonable risk to me though.  see examples below:

Without Text:
<img width="1238" alt="Screenshot 2025-01-01 at 23 13 04" src="https://github.com/user-attachments/assets/095dc9e8-ba39-4c8e-8536-b95a7eb549db" />

With Text:
<img width="1291" alt="Screenshot 2025-01-01 at 23 13 46" src="https://github.com/user-attachments/assets/803cbc83-e8ab-486a-8356-e1539b757db1" />