### PR TITLE
Issue 155 rotation

### DIFF
--- a/packages/backend/src/common/numToAutoFixed.ts
+++ b/packages/backend/src/common/numToAutoFixed.ts
@@ -1,9 +1,13 @@
 import { indentStringFlutter } from "./indentString";
 
 // this is necessary to avoid a height of 4.999999523162842.
-export const sliceNum = (num: number): string => {
+export const numberToFixedString = (num: number): string => {
   return num.toFixed(2).replace(/\.00$/, "");
 };
+
+export const roundToNearestDecimal = (decimal: number) => (n: number) =>
+  Math.round(n * 10 ** decimal) / 10 ** decimal;
+export const roundToNearestHundreth = roundToNearestDecimal(2);
 
 export const printPropertyIfNotDefault = (
   propertyName: string,
@@ -54,14 +58,14 @@ export const generateWidgetCode = (
         return `${key}: [\n${indentStringFlutter(value.join(",\n"))},\n],`;
       } else {
         return `${key}: ${
-          typeof value === "number" ? sliceNum(value) : value
+          typeof value === "number" ? numberToFixedString(value) : value
         },`;
       }
     });
 
   const positionedValuesString = (positionedValues || [])
     .map((value) => {
-      return typeof value === "number" ? sliceNum(value) : value;
+      return typeof value === "number" ? numberToFixedString(value) : value;
     })
     .join(", ");
 

--- a/packages/backend/src/common/parseJSX.ts
+++ b/packages/backend/src/common/parseJSX.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "./numToAutoFixed";
+import { numberToFixedString } from "./numToAutoFixed";
 
 export const formatWithJSX = (
   property: string,
@@ -13,9 +13,9 @@ export const formatWithJSX = (
 
   if (typeof value === "number") {
     if (isJsx) {
-      return `${jsx_property}: ${sliceNum(value)}`;
+      return `${jsx_property}: ${numberToFixedString(value)}`;
     } else {
-      return `${property}: ${sliceNum(value)}px`;
+      return `${property}: ${numberToFixedString(value)}px`;
     }
   } else if (isJsx) {
     return `${jsx_property}: '${value}'`;

--- a/packages/backend/src/flutter/builderImpl/flutterBlend.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterBlend.ts
@@ -1,4 +1,7 @@
-import { generateWidgetCode, sliceNum } from "../../common/numToAutoFixed";
+import {
+  generateWidgetCode,
+  numberToFixedString,
+} from "../../common/numToAutoFixed";
 
 /**
  * https://api.flutter.dev/flutter/widgets/Opacity-class.html
@@ -9,7 +12,7 @@ export const flutterOpacity = (
 ): string => {
   if (node.opacity !== undefined && node.opacity !== 1 && child !== "") {
     return generateWidgetCode("Opacity", {
-      opacity: sliceNum(node.opacity),
+      opacity: numberToFixedString(node.opacity),
       child: child,
     });
   }
@@ -43,7 +46,7 @@ export const flutterRotation = (node: LayoutMixin, child: string): string => {
     Math.round(node.rotation) !== 0
   ) {
     return generateWidgetCode("Transform", {
-      transform: `Matrix4.identity()..translate(0.0, 0.0)..rotateZ(${sliceNum(
+      transform: `Matrix4.identity()..translate(0.0, 0.0)..rotateZ(${numberToFixedString(
         node.rotation * (-3.14159 / 180),
       )})`,
       child: child,

--- a/packages/backend/src/flutter/builderImpl/flutterColor.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterColor.ts
@@ -1,6 +1,9 @@
 import { rgbTo8hex, gradientAngle } from "../../common/color";
 import { addWarning } from "../../common/commonConversionWarnings";
-import { generateWidgetCode, sliceNum } from "../../common/numToAutoFixed";
+import {
+  generateWidgetCode,
+  numberToFixedString,
+} from "../../common/numToAutoFixed";
 import { retrieveTopFill } from "../../common/retrieveFill";
 import { nearestValue } from "../../tailwind/conversionTables";
 
@@ -101,11 +104,11 @@ const flutterRadialGradient = (fill: GradientPaint): string => {
     .map((d) => flutterColor(d.color, d.color.a))
     .join(", ");
 
-  const x = sliceNum(fill.gradientTransform[0][2]);
-  const y = sliceNum(fill.gradientTransform[1][2]);
+  const x = numberToFixedString(fill.gradientTransform[0][2]);
+  const y = numberToFixedString(fill.gradientTransform[1][2]);
   const scaleX = fill.gradientTransform[0][0];
   const scaleY = fill.gradientTransform[1][1];
-  const r = sliceNum(Math.sqrt(scaleX * scaleX + scaleY * scaleY));
+  const r = numberToFixedString(Math.sqrt(scaleX * scaleX + scaleY * scaleY));
 
   return generateWidgetCode("RadialGradient", {
     center: `Alignment(${x}, ${y})`,
@@ -119,10 +122,10 @@ const flutterAngularGradient = (fill: GradientPaint): string => {
     .map((d) => flutterColor(d.color, d.color.a))
     .join(", ");
 
-  const x = sliceNum(fill.gradientTransform[0][2]);
-  const y = sliceNum(fill.gradientTransform[1][2]);
-  const startAngle = sliceNum(-fill.gradientTransform[0][0]);
-  const endAngle = sliceNum(-fill.gradientTransform[0][1]);
+  const x = numberToFixedString(fill.gradientTransform[0][2]);
+  const y = numberToFixedString(fill.gradientTransform[1][2]);
+  const startAngle = numberToFixedString(-fill.gradientTransform[0][0]);
+  const endAngle = numberToFixedString(-fill.gradientTransform[0][1]);
 
   return generateWidgetCode("SweepGradient", {
     center: `Alignment(${x}, ${y})`,

--- a/packages/backend/src/flutter/builderImpl/flutterPadding.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterPadding.ts
@@ -1,7 +1,7 @@
 import {
   generateWidgetCode,
   skipDefaultProperty,
-  sliceNum,
+  numberToFixedString,
 } from "../../common/numToAutoFixed";
 import { commonPadding } from "../../common/commonPadding";
 
@@ -18,22 +18,25 @@ export const flutterPadding = (node: InferredAutoLayoutResult): string => {
 
   if ("all" in padding) {
     return skipDefaultProperty(
-      `const EdgeInsets.all(${sliceNum(padding.all)})`,
+      `const EdgeInsets.all(${numberToFixedString(padding.all)})`,
       "const EdgeInsets.all(0)",
     );
   }
 
   if ("horizontal" in padding) {
     return generateWidgetCode("const EdgeInsets.symmetric", {
-      horizontal: skipDefaultProperty(sliceNum(padding.horizontal), "0"),
-      vertical: skipDefaultProperty(sliceNum(padding.vertical), "0"),
+      horizontal: skipDefaultProperty(
+        numberToFixedString(padding.horizontal),
+        "0",
+      ),
+      vertical: skipDefaultProperty(numberToFixedString(padding.vertical), "0"),
     });
   }
 
   return generateWidgetCode("const EdgeInsets.only", {
-    top: skipDefaultProperty(sliceNum(padding.top), "0"),
-    left: skipDefaultProperty(sliceNum(padding.left), "0"),
-    right: skipDefaultProperty(sliceNum(padding.right), "0"),
-    bottom: skipDefaultProperty(sliceNum(padding.bottom), "0"),
+    top: skipDefaultProperty(numberToFixedString(padding.top), "0"),
+    left: skipDefaultProperty(numberToFixedString(padding.left), "0"),
+    right: skipDefaultProperty(numberToFixedString(padding.right), "0"),
+    bottom: skipDefaultProperty(numberToFixedString(padding.bottom), "0"),
   });
 };

--- a/packages/backend/src/flutter/builderImpl/flutterShadow.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterShadow.ts
@@ -1,5 +1,8 @@
 import { rgbTo8hex } from "../../common/color";
-import { generateWidgetCode, sliceNum } from "../../common/numToAutoFixed";
+import {
+  generateWidgetCode,
+  numberToFixedString,
+} from "../../common/numToAutoFixed";
 import { indentStringFlutter } from "../../common/indentString";
 
 // TODO Document it can't do flutter shadows.
@@ -19,11 +22,13 @@ export const flutterShadow = (node: SceneNode): string => {
               effect.color,
               effect.color.a,
             ).toUpperCase()})`,
-            blurRadius: sliceNum(effect.radius),
-            offset: `Offset(${sliceNum(effect.offset.x)}, ${sliceNum(
+            blurRadius: numberToFixedString(effect.radius),
+            offset: `Offset(${numberToFixedString(effect.offset.x)}, ${numberToFixedString(
               effect.offset.y,
             )})`,
-            spreadRadius: effect.spread ? sliceNum(effect.spread) : "0",
+            spreadRadius: effect.spread
+              ? numberToFixedString(effect.spread)
+              : "0",
           });
         }
       });

--- a/packages/backend/src/flutter/builderImpl/flutterSize.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterSize.ts
@@ -1,5 +1,5 @@
 import { nodeSize } from "../../common/nodeWidthHeight";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 
 // Used in tests.
 export const flutterSizeWH = (node: SceneNode): string => {
@@ -23,7 +23,7 @@ export const flutterSize = (
   // this cast will always be true, since nodeWidthHeight was called with false to relative.
   let propWidth = "";
   if (typeof size.width === "number") {
-    propWidth = sliceNum(size.width);
+    propWidth = numberToFixedString(size.width);
   } else if (size.width === "fill") {
     // When parent is a Row, child must be Expanded.
     if (
@@ -39,7 +39,7 @@ export const flutterSize = (
 
   let propHeight = "";
   if (typeof size.height === "number") {
-    propHeight = sliceNum(size.height);
+    propHeight = numberToFixedString(size.height);
   } else if (size.height === "fill") {
     // When parent is a Column, child must be Expanded.
     if (

--- a/packages/backend/src/flutter/flutterContainer.ts
+++ b/packages/backend/src/flutter/flutterContainer.ts
@@ -10,7 +10,7 @@ import {
   generateWidgetCode,
   skipDefaultProperty,
 } from "../common/numToAutoFixed";
-import { sliceNum } from "../common/numToAutoFixed";
+import { numberToFixedString } from "../common/numToAutoFixed";
 import { getCommonRadius } from "../common/commonRadius";
 import { commonStroke } from "../common/commonStroke";
 
@@ -180,12 +180,12 @@ const generateStarBorder = (node: StarNode): string => {
 
   return generateWidgetCode("StarBorder", {
     side: generateBorderSideCode(node),
-    points: sliceNum(points),
-    innerRadiusRatio: sliceNum(innerRadiusRatio),
-    pointRounding: sliceNum(pointRounding),
-    valleyRounding: sliceNum(valleyRounding),
-    rotation: sliceNum(rotation),
-    squash: sliceNum(squash),
+    points: numberToFixedString(points),
+    innerRadiusRatio: numberToFixedString(innerRadiusRatio),
+    pointRounding: numberToFixedString(pointRounding),
+    valleyRounding: numberToFixedString(valleyRounding),
+    rotation: numberToFixedString(rotation),
+    squash: numberToFixedString(squash),
   });
 };
 
@@ -219,7 +219,7 @@ const generatePolygonBorder = (node: PolygonNode): string => {
 
   return generateWidgetCode("StarBorder.polygon", {
     side: generateBorderSideCode(node),
-    sides: sliceNum(points),
+    sides: numberToFixedString(points),
     borderRadius: generateBorderRadius(node),
   });
 };
@@ -230,24 +230,24 @@ const generateBorderRadius = (node: SceneNode): string => {
     if (radius.all === 0) {
       return "";
     }
-    return `BorderRadius.circular(${sliceNum(radius.all)})`;
+    return `BorderRadius.circular(${numberToFixedString(radius.all)})`;
   }
 
   return generateWidgetCode("BorderRadius.only", {
     topLeft: skipDefaultProperty(
-      `Radius.circular(${sliceNum(radius.topLeft)})`,
+      `Radius.circular(${numberToFixedString(radius.topLeft)})`,
       "Radius.circular(0)",
     ),
     topRight: skipDefaultProperty(
-      `Radius.circular(${sliceNum(radius.topRight)})`,
+      `Radius.circular(${numberToFixedString(radius.topRight)})`,
       "Radius.circular(0)",
     ),
     bottomLeft: skipDefaultProperty(
-      `Radius.circular(${sliceNum(radius.bottomLeft)})`,
+      `Radius.circular(${numberToFixedString(radius.bottomLeft)})`,
       "Radius.circular(0)",
     ),
     bottomRight: skipDefaultProperty(
-      `Radius.circular(${sliceNum(radius.bottomRight)})`,
+      `Radius.circular(${numberToFixedString(radius.bottomRight)})`,
       "Radius.circular(0)",
     ),
   });

--- a/packages/backend/src/flutter/flutterTextBuilder.ts
+++ b/packages/backend/src/flutter/flutterTextBuilder.ts
@@ -1,7 +1,7 @@
 import {
   generateWidgetCode,
   skipDefaultProperty,
-  sliceNum,
+  numberToFixedString,
 } from "./../common/numToAutoFixed";
 import { FlutterDefaultBuilder } from "./flutterDefaultBuilder";
 import { flutterColorFromFills } from "./builderImpl/flutterColor";
@@ -71,7 +71,7 @@ export class FlutterTextBuilder extends FlutterDefaultBuilder {
     return segments.map((segment) => {
       const color = flutterColorFromFills(segment.fills);
 
-      const fontSize = `${sliceNum(segment.fontSize)}`;
+      const fontSize = `${numberToFixedString(segment.fontSize)}`;
       const fontStyle = this.fontStyle(segment.fontName);
       const fontFamily = `'${segment.fontName.family}'`;
       const fontWeight = `FontWeight.w${segment.fontWeight}`;
@@ -139,16 +139,16 @@ export class FlutterTextBuilder extends FlutterDefaultBuilder {
       case "AUTO":
         return "";
       case "PIXELS":
-        return sliceNum(lineHeight.value / fontSize);
+        return numberToFixedString(lineHeight.value / fontSize);
       case "PERCENT":
-        return sliceNum(lineHeight.value / 100);
+        return numberToFixedString(lineHeight.value / 100);
     }
   }
 
   letterSpacing(letterSpacing: LetterSpacing, fontSize: number): string {
     const value = commonLetterSpacing(letterSpacing, fontSize);
     if (value) {
-      return sliceNum(value);
+      return numberToFixedString(value);
     }
     return "";
   }

--- a/packages/backend/src/html/builderImpl/htmlBlend.ts
+++ b/packages/backend/src/html/builderImpl/htmlBlend.ts
@@ -1,4 +1,6 @@
-import { sliceNum } from "../../common/numToAutoFixed";
+import { roundToNearestHundreth } from "./../../common/numToAutoFixed";
+import { addWarning } from "../../common/commonConversionWarnings";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { formatWithJSX } from "../../common/parseJSX";
 
 /**
@@ -15,9 +17,9 @@ export const htmlOpacity = (
   if (node.opacity !== undefined && node.opacity !== 1) {
     // formatWithJSX is not called here because opacity unit doesn't end in px.
     if (isJsx) {
-      return `opacity: ${sliceNum(node.opacity)}`;
+      return `opacity: ${numberToFixedString(node.opacity)}`;
     } else {
-      return `opacity: ${sliceNum(node.opacity)}`;
+      return `opacity: ${numberToFixedString(node.opacity)}`;
     }
   }
   return "";
@@ -124,10 +126,23 @@ export const htmlRotation = (node: LayoutMixin, isJsx: boolean): string[] => {
     parent && "rotation" in parent ? parent.rotation : 0;
   const rotation: number = Math.round(parentRotation - node.rotation) ?? 0;
 
+  if (
+    roundToNearestHundreth(parentRotation) !== 0 &&
+    roundToNearestHundreth(rotation) !== 0
+  ) {
+    addWarning(
+      "Rotated elements within rotated containers are not currently supported.",
+    );
+  }
+
   if (rotation !== 0) {
     return [
-      formatWithJSX("transform", isJsx, `rotate(${sliceNum(rotation)}deg)`),
-      formatWithJSX("transform-origin", isJsx, "0 0"),
+      formatWithJSX(
+        "transform",
+        isJsx,
+        `rotate(${numberToFixedString(rotation)}deg)`,
+      ),
+      formatWithJSX("transform-origin", isJsx, "top left"),
     ];
   }
   return [];

--- a/packages/backend/src/html/builderImpl/htmlColor.ts
+++ b/packages/backend/src/html/builderImpl/htmlColor.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { retrieveTopFill } from "../../common/retrieveFill";
 
 // retrieve the SOLID color on HTML
@@ -47,10 +47,10 @@ export const htmlColor = (color: RGB, alpha: number = 1): string => {
     return `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
   }
 
-  const r = sliceNum(color.r * 255);
-  const g = sliceNum(color.g * 255);
-  const b = sliceNum(color.b * 255);
-  const a = sliceNum(alpha);
+  const r = numberToFixedString(color.r * 255);
+  const g = numberToFixedString(color.g * 255);
+  const b = numberToFixedString(color.b * 255);
+  const a = numberToFixedString(alpha);
 
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 };

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -17,7 +17,10 @@ import {
   commonIsAbsolutePosition,
   getCommonPositionValue,
 } from "../common/commonPosition";
-import { sliceNum, stringToClassName } from "../common/numToAutoFixed";
+import {
+  numberToFixedString,
+  stringToClassName,
+} from "../common/numToAutoFixed";
 import { commonStroke } from "../common/commonStroke";
 import {
   formatClassAttribute,
@@ -103,7 +106,9 @@ export class HtmlDefaultBuilder {
       "dashPattern" in node && node.dashPattern.length > 0 ? "dotted" : "solid";
 
     const consolidateBorders = (border: number): string =>
-      [`${sliceNum(border)}px`, color, borderStyle].filter((d) => d).join(" ");
+      [`${numberToFixedString(border)}px`, color, borderStyle]
+        .filter((d) => d)
+        .join(" ");
 
     if ("all" in commonBorder) {
       if (commonBorder.all === 0) {
@@ -290,7 +295,7 @@ export class HtmlDefaultBuilder {
           formatWithJSX(
             "filter",
             this.isJSX,
-            `blur(${sliceNum(blur.radius)}px)`,
+            `blur(${numberToFixedString(blur.radius)}px)`,
           ),
         );
       }
@@ -303,7 +308,7 @@ export class HtmlDefaultBuilder {
           formatWithJSX(
             "backdrop-filter",
             this.isJSX,
-            `blur(${sliceNum(backgroundBlur.radius)}px)`,
+            `blur(${numberToFixedString(backgroundBlur.radius)}px)`,
           ),
         );
       }

--- a/packages/backend/src/swiftui/builderImpl/swiftuiBlend.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiBlend.ts
@@ -1,5 +1,5 @@
 import { SwiftUIModifier } from "types";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 
 /**
  * https://developer.apple.com/documentation/swiftui/view/opacity(_:)
@@ -8,7 +8,7 @@ export const swiftuiOpacity = (
   node: MinimalBlendMixin,
 ): SwiftUIModifier | null => {
   if (node.opacity !== undefined && node.opacity !== 1) {
-    return ["opacity", sliceNum(node.opacity)];
+    return ["opacity", numberToFixedString(node.opacity)];
   }
   return null;
 };
@@ -31,7 +31,10 @@ export const swiftuiVisibility = (
  */
 export const swiftuiRotation = (node: LayoutMixin): SwiftUIModifier | null => {
   if (node.rotation !== undefined && Math.round(node.rotation) !== 0) {
-    return ["rotationEffect", `.degrees(${sliceNum(node.rotation)})`];
+    return [
+      "rotationEffect",
+      `.degrees(${numberToFixedString(node.rotation)})`,
+    ];
   }
   return null;
 };

--- a/packages/backend/src/swiftui/builderImpl/swiftuiBorder.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiBorder.ts
@@ -1,6 +1,6 @@
 import { commonStroke } from "./../../common/commonStroke";
 import { getCommonRadius } from "../../common/commonRadius";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { swiftUISolidColor } from "./swiftuiColor";
 import { SwiftUIElement } from "./swiftuiParser";
 import { SwiftUIModifier } from "types";
@@ -50,7 +50,7 @@ export const swiftuiBorder = (node: SceneNode): string[] | null => {
 
       const strokeModifier: SwiftUIModifier = [
         "stroke",
-        `${strokeColor}, lineWidth: ${sliceNum(width)}`,
+        `${strokeColor}, lineWidth: ${numberToFixedString(width)}`,
       ];
 
       if (strokeColor) {
@@ -84,9 +84,9 @@ const strokeInset = (
 ): [string, string | null] => {
   switch (node.strokeAlign) {
     case "INSIDE":
-      return ["inset", `by: ${sliceNum(width)}`];
+      return ["inset", `by: ${numberToFixedString(width)}`];
     case "OUTSIDE":
-      return ["inset", `by: -${sliceNum(width)}`];
+      return ["inset", `by: -${numberToFixedString(width)}`];
     case "CENTER":
       return ["inset", null];
   }
@@ -104,7 +104,7 @@ export const swiftuiCornerRadius = (node: SceneNode): string => {
   const radius = getCommonRadius(node);
   if ("all" in radius) {
     if (radius.all > 0) {
-      return sliceNum(radius.all);
+      return numberToFixedString(radius.all);
     } else {
       return "";
     }
@@ -119,7 +119,7 @@ export const swiftuiCornerRadius = (node: SceneNode): string => {
   );
 
   if (maxBorder > 0) {
-    return sliceNum(maxBorder);
+    return numberToFixedString(maxBorder);
   }
 
   return "";

--- a/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
@@ -1,7 +1,7 @@
 import { retrieveTopFill } from "../../common/retrieveFill";
 import { gradientAngle } from "../../common/color";
 import { nearestValue } from "../../tailwind/conversionTables";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { addWarning } from "../../common/commonConversionWarnings";
 
 export const swiftUISolidColor = (fill: Paint): string => {
@@ -116,11 +116,12 @@ export const swiftuiColor = (color: RGB, opacity: number): string => {
     return ".white";
   }
 
-  const r = `red: ${sliceNum(color.r)}`;
-  const g = `green: ${sliceNum(color.g)}`;
-  const b = `blue: ${sliceNum(color.b)}`;
+  const r = `red: ${numberToFixedString(color.r)}`;
+  const g = `green: ${numberToFixedString(color.g)}`;
+  const b = `blue: ${numberToFixedString(color.b)}`;
 
-  const opacityAttr = opacity !== 1.0 ? `.opacity(${sliceNum(opacity)})` : "";
+  const opacityAttr =
+    opacity !== 1.0 ? `.opacity(${numberToFixedString(opacity)})` : "";
 
   return `Color(${r}, ${g}, ${b})${opacityAttr}`;
 };

--- a/packages/backend/src/swiftui/builderImpl/swiftuiEffects.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiEffects.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { SwiftUIModifier } from "types";
 
 export const swiftuiShadow = (node: SceneNode): SwiftUIModifier | null => {
@@ -20,15 +20,17 @@ export const swiftuiShadow = (node: SceneNode): SwiftUIModifier | null => {
 
   const color = shadow.color;
   // set color when not black with 0.25 of opacity, which is the Figma default. Round the alpha now to avoid rounding issues.
-  const a = sliceNum(color.a);
-  const r = sliceNum(color.r);
-  const g = sliceNum(color.g);
-  const b = sliceNum(color.b);
+  const a = numberToFixedString(color.a);
+  const r = numberToFixedString(color.r);
+  const g = numberToFixedString(color.g);
+  const b = numberToFixedString(color.b);
   comp.push(`color: Color(red: ${r}, green: ${g}, blue: ${b}, opacity: ${a})`);
-  comp.push(`radius: ${sliceNum(shadow.radius)}`);
+  comp.push(`radius: ${numberToFixedString(shadow.radius)}`);
 
-  const x = shadow.offset.x > 0 ? `x: ${sliceNum(shadow.offset.x)}` : "";
-  const y = shadow.offset.y > 0 ? `y: ${sliceNum(shadow.offset.y)}` : "";
+  const x =
+    shadow.offset.x > 0 ? `x: ${numberToFixedString(shadow.offset.x)}` : "";
+  const y =
+    shadow.offset.y > 0 ? `y: ${numberToFixedString(shadow.offset.y)}` : "";
 
   // add initial comma since this is an optional paramater and radius must come first.
   if (x && y) {
@@ -59,5 +61,5 @@ export const swiftuiBlur = (node: SceneNode): SwiftUIModifier | null => {
 
   // retrieve first blur.
   const blur = layerBlur[0].radius;
-  return ["blur", `radius: ${sliceNum(blur)})`];
+  return ["blur", `radius: ${numberToFixedString(blur)})`];
 };

--- a/packages/backend/src/swiftui/builderImpl/swiftuiPadding.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiPadding.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { commonPadding } from "../../common/commonPadding";
 import { SwiftUIModifier } from "types";
 
@@ -18,22 +18,22 @@ export const swiftuiPadding = (
     if (padding.all === 0) {
       return null;
     }
-    return ["padding", sliceNum(padding.all)];
+    return ["padding", numberToFixedString(padding.all)];
   }
 
   if ("horizontal" in padding) {
-    const vertical = sliceNum(padding.vertical);
-    const horizontal = sliceNum(padding.horizontal);
+    const vertical = numberToFixedString(padding.vertical);
+    const horizontal = numberToFixedString(padding.horizontal);
     return [
       "padding",
       `EdgeInsets(top: ${vertical}, leading: ${horizontal}, bottom: ${vertical}, trailing: ${horizontal})`,
     ];
   }
 
-  const top = sliceNum(padding.top);
-  const left = sliceNum(padding.left);
-  const bottom = sliceNum(padding.bottom);
-  const right = sliceNum(padding.right);
+  const top = numberToFixedString(padding.top);
+  const left = numberToFixedString(padding.left);
+  const bottom = numberToFixedString(padding.bottom);
+  const right = numberToFixedString(padding.right);
   return [
     "padding",
     `EdgeInsets(top: ${top}, leading: ${left}, bottom: ${bottom}, trailing: ${right})`,

--- a/packages/backend/src/swiftui/builderImpl/swiftuiSize.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiSize.ts
@@ -1,5 +1,5 @@
 import { nodeSize } from "../../common/nodeWidthHeight";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 
 export const swiftuiSize = (
   node: SceneNode,
@@ -13,7 +13,7 @@ export const swiftuiSize = (
   // this cast will always be true, since nodeWidthHeight was called with false to relative.
   let propWidth = "";
   if (typeof size.width === "number") {
-    const w = sliceNum(size.width);
+    const w = numberToFixedString(size.width);
 
     if (shouldExtend) {
       propWidth = `minWidth: ${w}, maxWidth: ${w}`;
@@ -26,7 +26,7 @@ export const swiftuiSize = (
 
   let propHeight = "";
   if (typeof size.height === "number") {
-    const h = sliceNum(size.height);
+    const h = numberToFixedString(size.height);
 
     if (shouldExtend) {
       propHeight = `minHeight: ${h}, maxHeight: ${h}`;

--- a/packages/backend/src/swiftui/swiftuiDefaultBuilder.ts
+++ b/packages/backend/src/swiftui/swiftuiDefaultBuilder.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "./../common/numToAutoFixed";
+import { numberToFixedString } from "./../common/numToAutoFixed";
 import { swiftuiBlur, swiftuiShadow } from "./builderImpl/swiftuiEffects";
 import {
   swiftuiBorder,
@@ -87,7 +87,7 @@ export class SwiftuiDefaultBuilder {
 
       this.pushModifier([
         `offset`,
-        `x: ${sliceNum(centerX)}, y: ${sliceNum(centerY)}`,
+        `x: ${numberToFixedString(centerX)}, y: ${numberToFixedString(centerY)}`,
       ]);
     }
     return this;

--- a/packages/backend/src/swiftui/swiftuiMain.ts
+++ b/packages/backend/src/swiftui/swiftuiMain.ts
@@ -1,5 +1,8 @@
 import { indentString } from "../common/indentString";
-import { stringToClassName, sliceNum } from "../common/numToAutoFixed";
+import {
+  stringToClassName,
+  numberToFixedString,
+} from "../common/numToAutoFixed";
 import { SwiftuiTextBuilder } from "./swiftuiTextBuilder";
 import { SwiftuiDefaultBuilder } from "./swiftuiDefaultBuilder";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
@@ -222,7 +225,7 @@ export const generateSwiftViewCode = (
     .filter(([, value]) => value !== "")
     .map(
       ([key, value]) =>
-        `${key}: ${typeof value === "number" ? sliceNum(value) : value}`,
+        `${key}: ${typeof value === "number" ? numberToFixedString(value) : value}`,
     );
 
   const compactPropertiesArray = propertiesArray.join(", ");

--- a/packages/backend/src/swiftui/swiftuiTextBuilder.ts
+++ b/packages/backend/src/swiftui/swiftuiTextBuilder.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "../common/numToAutoFixed";
+import { numberToFixedString } from "../common/numToAutoFixed";
 import {
   commonLetterSpacing,
   commonLineHeight,
@@ -109,7 +109,7 @@ export class SwiftuiTextBuilder extends SwiftuiDefaultBuilder {
     const segment = segments[0];
 
     // return segments.map((segment) => {
-    const fontSize = sliceNum(segment.fontSize);
+    const fontSize = numberToFixedString(segment.fontSize);
     const fontFamily = segment.fontName.family;
     const fontWeight = this.fontWeight(segment.fontWeight);
     const lineHeight = this.lineHeight(segment.lineHeight, segment.fontSize);
@@ -150,7 +150,7 @@ export class SwiftuiTextBuilder extends SwiftuiDefaultBuilder {
   ): string | null => {
     const value = commonLetterSpacing(letterSpacing, fontSize);
     if (value > 0) {
-      return sliceNum(value);
+      return numberToFixedString(value);
     }
     return null;
   };
@@ -160,7 +160,7 @@ export class SwiftuiTextBuilder extends SwiftuiDefaultBuilder {
   lineHeight = (lineHeight: LineHeight, fontSize: number): string | null => {
     const value = commonLineHeight(lineHeight, fontSize);
     if (value > 0) {
-      return sliceNum(value);
+      return numberToFixedString(value);
     }
     return null;
   };

--- a/packages/backend/src/tailwind/builderImpl/tailwindBlend.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindBlend.ts
@@ -1,4 +1,4 @@
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { exactValue, nearestOpacity, nearestValue } from "../conversionTables";
 
 /**
@@ -93,7 +93,7 @@ export const tailwindRotation = (node: LayoutMixin): string => {
 
       return `origin-top-left ${minusIfNegative}rotate-${nearest}`;
     } else {
-      return `origin-top-left rotate-[${sliceNum(-node.rotation)}deg]`;
+      return `origin-top-left rotate-[${numberToFixedString(-node.rotation)}deg]`;
     }
   }
   return "";

--- a/packages/backend/src/tailwind/builderImpl/tailwindBorder.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindBorder.ts
@@ -1,6 +1,6 @@
 import { getCommonRadius } from "../../common/commonRadius";
 import { commonStroke } from "../../common/commonStroke";
-import { sliceNum } from "../../common/numToAutoFixed";
+import { numberToFixedString } from "../../common/numToAutoFixed";
 import { nearestValue, pxToBorderRadius } from "../conversionTables";
 
 /**

--- a/packages/backend/src/tailwind/conversionTables.ts
+++ b/packages/backend/src/tailwind/conversionTables.ts
@@ -1,5 +1,5 @@
 import { nearestColorFrom } from "../nearest-color/nearestColor";
-import { sliceNum } from "../common/numToAutoFixed";
+import { numberToFixedString } from "../common/numToAutoFixed";
 import { localTailwindSettings } from "./tailwindMain";
 import { config } from "./tailwindConfig";
 import { rgbTo6hex } from "../common/color";
@@ -44,7 +44,7 @@ const pxToRemToTailwind = (
     return conversionMap[nearestValue(value / 16, keys)];
   }
 
-  return `[${sliceNum(value)}px]`;
+  return `[${numberToFixedString(value)}px]`;
 };
 
 const pxToTailwind = (
@@ -60,7 +60,7 @@ const pxToTailwind = (
     return conversionMap[nearestValue(value, keys)];
   }
 
-  return `[${sliceNum(value)}px]`;
+  return `[${numberToFixedString(value)}px]`;
 };
 
 export const pxToLetterSpacing = (value: number): string => {
@@ -89,7 +89,7 @@ export const pxToLayoutSize = (value: number): string => {
     return tailwindValue;
   }
 
-  return `[${sliceNum(value)}px]`;
+  return `[${numberToFixedString(value)}px]`;
 };
 
 export const nearestOpacity = (nodeOpacity: number): number => {
@@ -115,8 +115,10 @@ export const nearestColorFromRgb = (color: RGB) => {
 
 export const variableToColorName = (alias: VariableAlias) => {
   return (
-    figma.variables.getVariableById(alias.id)?.name.replaceAll("/", "-").replaceAll(" ", "-") || 
-    alias.id.toLowerCase().replaceAll(":", "-")
+    figma.variables
+      .getVariableById(alias.id)
+      ?.name.replaceAll("/", "-")
+      .replaceAll(" ", "-") || alias.id.toLowerCase().replaceAll(":", "-")
   );
 };
 
@@ -138,16 +140,16 @@ export function getColorInfo(fill: SolidPaint | ColorStop) {
       colorType: "tailwind",
       colorName: "black",
       hex: "#000000",
-      meta: ''
+      meta: "",
     };
   }
 
   if (fill.color.r === 1 && fill.color.g === 1 && fill.color.b === 1) {
     return {
-      colorType: "tailwind", 
+      colorType: "tailwind",
       colorName: "white",
       hex: "#ffffff",
-      meta: ''
+      meta: "",
     };
   }
 

--- a/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
@@ -1,4 +1,7 @@
-import { stringToClassName, sliceNum } from "./../common/numToAutoFixed";
+import {
+  stringToClassName,
+  numberToFixedString,
+} from "./../common/numToAutoFixed";
 import { tailwindShadow } from "./builderImpl/tailwindShadow";
 import {
   tailwindVisibility,
@@ -118,8 +121,8 @@ export class TailwindDefaultBuilder {
     if (commonIsAbsolutePosition(node, optimizeLayout)) {
       const { x, y } = getCommonPositionValue(node);
 
-      const parsedX = sliceNum(x);
-      const parsedY = sliceNum(y);
+      const parsedX = numberToFixedString(x);
+      const parsedY = numberToFixedString(y);
       if (parsedX === "0") {
         this.addAttributes(`left-0`);
       } else {


### PR DESCRIPTION
I was able to improve the rotations but not totally fix the issues in #155. 

When there are rotated elements inside of a rotated group, the position of the child elements is not correct. This has to do with the strange way that Figma calculates the positioning. It seems to give you the absolute positioning of the child elements when the group is rotated, rather than the relative position. I'm sure there's a way to work backwards to get the correct position relative to the parent coordinate space, and I'm sure that it involves using trigonometry, but I don't have the patience for doing that right now, and I don't think that it is a high priority for me at this point. 

Instead, I've added a warning when it detects rotated children inside a rotated group.