### PR TITLE
Shadow and blur effects support for text layers, Tailwind prefix support and new placeholder service

### DIFF
--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -105,15 +105,15 @@ const codegenMode = async () => {
   // figma.showUI(__html__, { visible: false });
   await getUserSettings();
 
-  figma.codegen.on("generate", ({ language, node }) => {
+  figma.codegen.on("generate", async ({ language, node }: CodegenEvent): Promise<CodegenResult[]> => {
     const convertedSelection = convertIntoNodes([node], null);
 
     switch (language) {
       case "html":
         return [
           {
-            title: `Code`,
-            code: htmlMain(
+            title: "Code",
+            code: await htmlMain(
               convertedSelection,
               { ...userPluginSettings, jsx: false },
               true,
@@ -121,7 +121,7 @@ const codegenMode = async () => {
             language: "HTML",
           },
           {
-            title: `Text Styles`,
+            title: "Text Styles",
             code: htmlCodeGenTextStyles(userPluginSettings),
             language: "HTML",
           },
@@ -129,8 +129,8 @@ const codegenMode = async () => {
       case "html_jsx":
         return [
           {
-            title: `Code`,
-            code: htmlMain(
+            title: "Code",
+            code: await htmlMain(
               convertedSelection,
               { ...userPluginSettings, jsx: true },
               true,
@@ -138,7 +138,7 @@ const codegenMode = async () => {
             language: "HTML",
           },
           {
-            title: `Text Styles`,
+            title: "Text Styles",
             code: htmlCodeGenTextStyles(userPluginSettings),
             language: "HTML",
           },
@@ -147,20 +147,20 @@ const codegenMode = async () => {
       case "tailwind_jsx":
         return [
           {
-            title: `Code`,
-            code: tailwindMain(convertedSelection, {
+            title: "Code",
+            code: await tailwindMain(convertedSelection, {
               ...userPluginSettings,
               jsx: language === "tailwind_jsx",
             }),
             language: "HTML",
           },
           // {
-          //   title: `Style`,
+          //   title: "Style",
           //   code: tailwindMain(convertedSelection, defaultPluginSettings),
           //   language: "HTML",
           // },
           {
-            title: `Tailwind Colors`,
+            title: "Tailwind Colors",
             code: retrieveGenericSolidUIColors("Tailwind")
               .map((d) => {
                 let str = `${d.hex};`;
@@ -176,7 +176,7 @@ const codegenMode = async () => {
             language: "JAVASCRIPT",
           },
           {
-            title: `Text Styles`,
+            title: "Text Styles",
             code: tailwindCodeGenTextStyles(),
             language: "HTML",
           },
@@ -184,7 +184,7 @@ const codegenMode = async () => {
       case "flutter":
         return [
           {
-            title: `Code`,
+            title: "Code",
             code: flutterMain(convertedSelection, {
               ...userPluginSettings,
               flutterGenerationMode: "snippet",
@@ -192,7 +192,7 @@ const codegenMode = async () => {
             language: "SWIFT",
           },
           {
-            title: `Text Styles`,
+            title: "Text Styles",
             code: flutterCodeGenTextStyles(),
             language: "SWIFT",
           },
@@ -200,7 +200,7 @@ const codegenMode = async () => {
       case "swiftUI":
         return [
           {
-            title: `SwiftUI`,
+            title: "SwiftUI",
             code: swiftuiMain(convertedSelection, {
               ...userPluginSettings,
               swiftUIGenerationMode: "snippet",
@@ -208,7 +208,7 @@ const codegenMode = async () => {
             language: "SWIFT",
           },
           {
-            title: `Text Styles`,
+            title: "Text Styles",
             code: swiftUICodeGenTextStyles(),
             language: "SWIFT",
           },

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "capabilities": ["inspect", "codegen", "vscode"],
   "permissions": [],
   "networkAccess": {
-    "allowedDomains": ["none"]
+    "allowedDomains": ["https://placehold.co"]
   },
   "codegenLanguages": [
     { "label": "HTML", "value": "html" },

--- a/packages/backend/src/flutter/builderImpl/flutterColor.ts
+++ b/packages/backend/src/flutter/builderImpl/flutterColor.ts
@@ -56,7 +56,7 @@ export const flutterBoxDecorationColor = (
 export const flutterDecorationImage = (node: SceneNode, fill: ImagePaint) => {
   addWarning("Image fills are replaced with placeholders");
   return generateWidgetCode("DecorationImage", {
-    image: `NetworkImage("https://via.placeholder.com/${node.width.toFixed(
+    image: `NetworkImage("https://placehold.co/${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}")`,
     fit: fitToBoxFit(fill),

--- a/packages/backend/src/flutter/flutterMain.ts
+++ b/packages/backend/src/flutter/flutterMain.ts
@@ -148,7 +148,7 @@ const flutterContainer = (node: SceneNode, child: string): string => {
   let image = "";
   if ("fills" in node && retrieveTopFill(node.fills)?.type === "IMAGE") {
     addWarning("Image fills are replaced with placeholders");
-    image = `Image.network("https://via.placeholder.com/${node.width.toFixed(
+    image = `Image.network("https://placehold.co/${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}")`;
   }

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -225,7 +225,7 @@ const htmlAsset = (node: SceneNode, settings: HTMLSettings): string => {
   if (retrieveTopFill(node.fills)?.type === "IMAGE") {
     addWarning("Image fills are replaced with placeholders");
     tag = "img";
-    src = ` src="https://via.placeholder.com/${node.width.toFixed(
+    src = ` src="https://placehold.co/$${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}"`;
   }
@@ -268,7 +268,7 @@ const htmlContainer = (
       addWarning("Image fills are replaced with placeholders");
       if (!("children" in node) || node.children.length === 0) {
         tag = "img";
-        src = ` src="https://via.placeholder.com/${node.width.toFixed(
+        src = ` src="https://placehold.co/${node.width.toFixed(
           0,
         )}x${node.height.toFixed(0)}"`;
       } else {
@@ -276,7 +276,7 @@ const htmlContainer = (
           formatWithJSX(
             "background-image",
             settings.jsx,
-            `url(https://via.placeholder.com/${node.width.toFixed(
+            `url(https://placehold.co/${node.width.toFixed(
               0,
             )}x${node.height.toFixed(0)})`,
           ),

--- a/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
+++ b/packages/backend/src/swiftui/builderImpl/swiftuiColor.ts
@@ -60,7 +60,7 @@ export const swiftuiBackground = (
     return swiftuiGradient(fill);
   } else if (fill?.type === "IMAGE") {
     addWarning("Image fills are replaced with placeholders");
-    return `AsyncImage(url: URL(string: "https://via.placeholder.com/${node.width.toFixed(
+    return `AsyncImage(url: URL(string: "https://placehold.co/${node.width.toFixed(
       0,
     )}x${node.height.toFixed(0)}"))`;
   }

--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -84,16 +84,27 @@ export const tailwindGradientFromFills = (
   fills: ReadonlyArray<Paint> | PluginAPI["mixed"],
 ): string => {
   // [when testing] node.effects can be undefined
-
   const fill = retrieveTopFill(fills);
 
-  if (fill?.type === "GRADIENT_LINEAR") {
+  // Return early if no fill exists
+  if (!fill) {
+    return "";
+  }
+
+  if (fill.type === "GRADIENT_LINEAR") {
     return tailwindGradient(fill);
   }
 
-  addWarning(
-    "Gradients are not fully supported in Tailwind except for Linear Gradients.",
-  );
+  // Show warning if there's a non-linear gradient
+  if (
+    fill.type === "GRADIENT_ANGULAR" ||
+    fill.type === "GRADIENT_RADIAL" ||
+    fill.type === "GRADIENT_DIAMOND"
+  ) {
+    addWarning(
+      "Gradients are not fully supported in Tailwind except for Linear Gradients.",
+    );
+  }
 
   return "";
 };

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -234,12 +234,12 @@ export const tailwindContainer = (
       addWarning("Image fills are replaced with placeholders");
       if (!("children" in node) || node.children.length === 0) {
         tag = "img";
-        src = ` src="https://via.placeholder.com/${node.width.toFixed(
+        src = ` src="https://placehold.co/${node.width.toFixed(
           0,
         )}x${node.height.toFixed(0)}"`;
       } else {
         builder.addAttributes(
-          `bg-[url(https://via.placeholder.com/${node.width.toFixed(
+          `bg-[url(https://placehold.co/${node.width.toFixed(
             0,
           )}x${node.height.toFixed(0)})]`,
         );

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -9,6 +9,7 @@ export interface TailwindSettings extends HTMLSettings {
   roundTailwindValues: boolean;
   roundTailwindColors: boolean;
   customTailwindColors: boolean;
+  customTailwindPrefix?: string;
 }
 export interface FlutterSettings {
   flutterGenerationMode: string;


### PR DESCRIPTION
1. The old placeholder service ([placeholder.com](https://placeholder.com)) does not work anymore. It now uses [placehold.co](https://placehold.co) which exists since 2021.
2. The warning messages in Tailwind mode for fill gradients are "smarter" now.
3. Add support for text shadow and layer blur effects across all text builders (HTML, Tailwind, Flutter and SwiftUI)
4. Add custom prefix support for Tailwind classes in code generation

https://github.com/user-attachments/assets/ad645cfe-6159-461d-b1c2-b52f83f3eaea

![JxNSdWu](https://github.com/user-attachments/assets/c8996301-10e7-46bb-9c23-f89437818441)

<img width="447" alt="Bildschirmfoto 2025-02-07 um 19 49 33" src="https://github.com/user-attachments/assets/c354560f-e1cb-4274-a115-4b722b9cccfb" />


