### PR TITLE
Export images for HTML

### DIFF
--- a/apps/debug/pages/index.tsx
+++ b/apps/debug/pages/index.tsx
@@ -19,6 +19,7 @@ export default function Web() {
             <PluginFigmaToolbar variant="(Light)" />
             <PluginUI
               code={"code goes hereeeee"}
+              isLoading={false}
               selectedFramework={selectedFramework}
               setSelectedFramework={setSelectedFramework}
               htmlPreview={null}
@@ -36,6 +37,7 @@ export default function Web() {
             <PluginFigmaToolbar variant="(Dark)" />
             <PluginUI
               code={"code goes hereeeee"}
+              isLoading={false}
               selectedFramework={selectedFramework}
               setSelectedFramework={setSelectedFramework}
               htmlPreview={null}

--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -29,6 +29,7 @@ export const defaultPluginSettings: PluginSettings = {
   roundTailwindColors: false,
   customTailwindColors: false,
   customTailwindPrefix: "",
+  embedImages: false,
 };
 
 // A helper type guard to ensure the key belongs to the PluginSettings type

--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -28,6 +28,7 @@ export const defaultPluginSettings: PluginSettings = {
   roundTailwindValues: false,
   roundTailwindColors: false,
   customTailwindColors: false,
+  customTailwindPrefix: "",
 };
 
 // A helper type guard to ensure the key belongs to the PluginSettings type
@@ -86,6 +87,10 @@ const standardMode = async () => {
 
   // Listen for document changes
   figma.on("documentchange", () => {
+    // FIXME: This is causing an infinite load when you try to export a background image from a group that contains children.
+    // The reason for this is that the code will temporarily hide the children of the group in order to export a clean image
+    // then restores the visibility of the children. This constitutes a document change so it's restarting the whole conversion.
+    // In order to stop this, we may want to disable this listener when doing conversions (while isLoading === true).
     safeRun(userPluginSettings);
   });
 
@@ -105,121 +110,124 @@ const codegenMode = async () => {
   // figma.showUI(__html__, { visible: false });
   await getUserSettings();
 
-  figma.codegen.on("generate", async ({ language, node }: CodegenEvent): Promise<CodegenResult[]> => {
-    const convertedSelection = convertIntoNodes([node], null);
+  figma.codegen.on(
+    "generate",
+    async ({ language, node }: CodegenEvent): Promise<CodegenResult[]> => {
+      const convertedSelection = convertIntoNodes([node], null);
 
-    switch (language) {
-      case "html":
-        return [
-          {
-            title: "Code",
-            code: await htmlMain(
-              convertedSelection,
-              { ...userPluginSettings, jsx: false },
-              true,
-            ),
-            language: "HTML",
-          },
-          {
-            title: "Text Styles",
-            code: htmlCodeGenTextStyles(userPluginSettings),
-            language: "HTML",
-          },
-        ];
-      case "html_jsx":
-        return [
-          {
-            title: "Code",
-            code: await htmlMain(
-              convertedSelection,
-              { ...userPluginSettings, jsx: true },
-              true,
-            ),
-            language: "HTML",
-          },
-          {
-            title: "Text Styles",
-            code: htmlCodeGenTextStyles(userPluginSettings),
-            language: "HTML",
-          },
-        ];
-      case "tailwind":
-      case "tailwind_jsx":
-        return [
-          {
-            title: "Code",
-            code: await tailwindMain(convertedSelection, {
-              ...userPluginSettings,
-              jsx: language === "tailwind_jsx",
-            }),
-            language: "HTML",
-          },
-          // {
-          //   title: "Style",
-          //   code: tailwindMain(convertedSelection, defaultPluginSettings),
-          //   language: "HTML",
-          // },
-          {
-            title: "Tailwind Colors",
-            code: retrieveGenericSolidUIColors("Tailwind")
-              .map((d) => {
-                let str = `${d.hex};`;
-                if (d.colorName !== d.hex) {
-                  str += ` // ${d.colorName}`;
-                }
-                if (d.meta) {
-                  str += ` (${d.meta})`;
-                }
-                return str;
-              })
-              .join("\n"),
-            language: "JAVASCRIPT",
-          },
-          {
-            title: "Text Styles",
-            code: tailwindCodeGenTextStyles(),
-            language: "HTML",
-          },
-        ];
-      case "flutter":
-        return [
-          {
-            title: "Code",
-            code: flutterMain(convertedSelection, {
-              ...userPluginSettings,
-              flutterGenerationMode: "snippet",
-            }),
-            language: "SWIFT",
-          },
-          {
-            title: "Text Styles",
-            code: flutterCodeGenTextStyles(),
-            language: "SWIFT",
-          },
-        ];
-      case "swiftUI":
-        return [
-          {
-            title: "SwiftUI",
-            code: swiftuiMain(convertedSelection, {
-              ...userPluginSettings,
-              swiftUIGenerationMode: "snippet",
-            }),
-            language: "SWIFT",
-          },
-          {
-            title: "Text Styles",
-            code: swiftUICodeGenTextStyles(),
-            language: "SWIFT",
-          },
-        ];
-      default:
-        break;
-    }
+      switch (language) {
+        case "html":
+          return [
+            {
+              title: "Code",
+              code: await htmlMain(
+                convertedSelection,
+                { ...userPluginSettings, jsx: false },
+                true,
+              ),
+              language: "HTML",
+            },
+            {
+              title: "Text Styles",
+              code: htmlCodeGenTextStyles(userPluginSettings),
+              language: "HTML",
+            },
+          ];
+        case "html_jsx":
+          return [
+            {
+              title: "Code",
+              code: await htmlMain(
+                convertedSelection,
+                { ...userPluginSettings, jsx: true },
+                true,
+              ),
+              language: "HTML",
+            },
+            {
+              title: "Text Styles",
+              code: htmlCodeGenTextStyles(userPluginSettings),
+              language: "HTML",
+            },
+          ];
+        case "tailwind":
+        case "tailwind_jsx":
+          return [
+            {
+              title: "Code",
+              code: await tailwindMain(convertedSelection, {
+                ...userPluginSettings,
+                jsx: language === "tailwind_jsx",
+              }),
+              language: "HTML",
+            },
+            // {
+            //   title: "Style",
+            //   code: tailwindMain(convertedSelection, defaultPluginSettings),
+            //   language: "HTML",
+            // },
+            {
+              title: "Tailwind Colors",
+              code: retrieveGenericSolidUIColors("Tailwind")
+                .map((d) => {
+                  let str = `${d.hex};`;
+                  if (d.colorName !== d.hex) {
+                    str += ` // ${d.colorName}`;
+                  }
+                  if (d.meta) {
+                    str += ` (${d.meta})`;
+                  }
+                  return str;
+                })
+                .join("\n"),
+              language: "JAVASCRIPT",
+            },
+            {
+              title: "Text Styles",
+              code: tailwindCodeGenTextStyles(),
+              language: "HTML",
+            },
+          ];
+        case "flutter":
+          return [
+            {
+              title: "Code",
+              code: flutterMain(convertedSelection, {
+                ...userPluginSettings,
+                flutterGenerationMode: "snippet",
+              }),
+              language: "SWIFT",
+            },
+            {
+              title: "Text Styles",
+              code: flutterCodeGenTextStyles(),
+              language: "SWIFT",
+            },
+          ];
+        case "swiftUI":
+          return [
+            {
+              title: "SwiftUI",
+              code: swiftuiMain(convertedSelection, {
+                ...userPluginSettings,
+                swiftUIGenerationMode: "snippet",
+              }),
+              language: "SWIFT",
+            },
+            {
+              title: "Text Styles",
+              code: swiftUICodeGenTextStyles(),
+              language: "SWIFT",
+            },
+          ];
+        default:
+          break;
+      }
 
-    const blocks: CodegenResult[] = [];
-    return blocks;
-  });
+      const blocks: CodegenResult[] = [];
+      return blocks;
+    },
+  );
 };
 
 switch (figma.mode) {

--- a/apps/plugin/ui-src/App.tsx
+++ b/apps/plugin/ui-src/App.tsx
@@ -111,14 +111,26 @@ export default function App() {
   }, []);
 
   const handleFrameworkChange = (updatedFramework: Framework) => {
-    setState((prevState) => ({
-      ...prevState,
-      // code: "// Loading...",
-      selectedFramework: updatedFramework,
-    }));
-    postUISettingsChangingMessage("framework", updatedFramework, {
-      targetOrigin: "*",
-    });
+    if (updatedFramework !== state.selectedFramework) {
+      setState((prevState) => ({
+        ...prevState,
+        // code: "// Loading...",
+        selectedFramework: updatedFramework,
+      }));
+      postUISettingsChangingMessage("framework", updatedFramework, {
+        targetOrigin: "*",
+      });
+    }
+  };
+  const handlePreferencesChange = (
+    key: keyof PluginSettings,
+    value: boolean | string,
+  ) => {
+    if (state.settings && state.settings[key] === value) {
+      // do nothing
+    } else {
+      postUISettingsChangingMessage(key, value, { targetOrigin: "*" });
+    }
   };
 
   const darkMode = figmaColorBgValue !== "#ffffff";
@@ -131,11 +143,9 @@ export default function App() {
         warnings={state.warnings}
         selectedFramework={state.selectedFramework}
         setSelectedFramework={handleFrameworkChange}
+        onPreferenceChanged={handlePreferencesChange}
         htmlPreview={state.htmlPreview}
         settings={state.settings}
-        onPreferenceChanged={(key: string, value: boolean | string) =>
-          postUISettingsChangingMessage(key, value, { targetOrigin: "*" })
-        }
         colors={state.colors}
         gradients={state.gradients}
       />

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@figma/plugin-typings": "^1.105.0",
+    "js-base64": "^3.7.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "types": "workspace:*"

--- a/packages/backend/src/altNodes/altNodeUtils.ts
+++ b/packages/backend/src/altNodes/altNodeUtils.ts
@@ -42,6 +42,11 @@ export const isTypeOrGroupOfTypes = curry(
   },
 );
 
+export const isSVGNode = (node: SceneNode) => {
+  const altNode = node as AltNode<typeof node>;
+  return altNode.canBeFlattened;
+};
+
 export const renderNodeAsSVG = async (node: SceneNode) =>
   await node.exportAsync({ format: "SVG_STRING" });
 

--- a/packages/backend/src/code.ts
+++ b/packages/backend/src/code.ts
@@ -19,6 +19,7 @@ import { convertToCode } from "./common/retrieveUI/convertToCode";
 
 export const run = async (settings: PluginSettings) => {
   clearWarnings();
+
   const { framework } = settings;
   const selection = figma.currentPage.selection;
 

--- a/packages/backend/src/common/images.ts
+++ b/packages/backend/src/common/images.ts
@@ -42,6 +42,11 @@ export const exportNodeAsBase64PNG = async <T extends ExportableNode>(
   node: AltNode<T> | ExportableNode,
   excludeChildren: boolean,
 ) => {
+  // Shorcut export if the node has already been converted.
+  if ("base64" in node && node.base64 !== "") {
+    return node.base64;
+  }
+
   let n: ExportableNode;
   if ("originalNode" in node) {
     n = node.originalNode;

--- a/packages/backend/src/common/images.ts
+++ b/packages/backend/src/common/images.ts
@@ -1,7 +1,61 @@
+import { AltNode, ExportableNode } from "types";
+import { btoa } from "js-base64";
+import { addWarning, warnings } from "./commonConversionWarnings";
+
 export const PLACEHOLDER_IMAGE_DOMAIN = "https://placehold.co";
 
 export const getPlaceholderImage = (w: number, h = -1) => {
   const _w = w.toFixed(0);
   const _h = (h < 0 ? w : h).toFixed(0);
   return `${PLACEHOLDER_IMAGE_DOMAIN}/${_w}x${_h}`;
+};
+
+const uint8ArrayToBase64 = (bytes: Uint8Array) => {
+  // Convert Uint8Array to binary string
+  const binaryString = bytes.reduce((data, byte) => {
+    return data + String.fromCharCode(byte);
+  }, "");
+
+  // Encode binary string to base64
+  return btoa(binaryString);
+};
+
+const fillIsImage = ({ type }: Paint) => type === "IMAGE";
+
+export const nodeHasImageFill = (node: MinimalFillsMixin): Boolean =>
+  node.fills && (node.fills as Paint[]).some(fillIsImage);
+
+export const exportNodeAsBase64PNG = async <T extends ExportableNode>(
+  node: AltNode<T> | ExportableNode,
+) => {
+  let n: ExportableNode;
+  if ("originalNode" in node) {
+    n = node.originalNode;
+  } else {
+    n = node;
+  }
+
+  if (n.exportAsync === undefined) {
+    console.log(n);
+    throw new TypeError(
+      "Something went wrong. This node doesn't have an exportAsync function. Maybe check the type before calling this function.",
+    );
+  }
+  const exportSettings: ExportSettingsImage = {
+    format: "PNG",
+    constraint: { type: "SCALE", value: 1 },
+  };
+
+  let bytes: Uint8Array<ArrayBufferLike> = new Uint8Array();
+  try {
+    bytes = await node.exportAsync(exportSettings);
+  } catch (error) {
+    throw error as Error;
+  }
+
+  // Encode binary string to base64
+  const base64Url = `data:image/png;base64,${uint8ArrayToBase64(bytes)}`;
+
+  addWarning("Some images exported as Base64 PNG");
+  return base64Url;
 };

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -14,9 +14,11 @@ import {
 import { isSVGNode, renderAndAttachSVG } from "../altNodes/altNodeUtils";
 import { getVisibleNodes } from "../common/nodeVisibility";
 import {
+  exportFillAsBase64PNG,
   exportNodeAsBase64PNG,
   getPlaceholderImage,
   nodeHasImageFill,
+  nodeHasMultipleFills,
 } from "../common/images";
 import { addWarning } from "../common/commonConversionWarnings";
 
@@ -253,23 +255,64 @@ const htmlContainer = async (
     let src = "";
 
     if (nodeHasImageFill(node)) {
-      let imgUrl: String;
       const altNode = node as AltNode<ExportableNode>;
 
       // if node has NO children
       if (!("children" in node) || node.children.length === 0) {
-        imgUrl = await exportNodeAsBase64PNG(altNode.originalNode);
+        const imgUrl = await exportNodeAsBase64PNG(altNode.originalNode);
         tag = "img";
         src = ` src="${imgUrl}"`;
-      } else {
-        // imgUrl = await exportNodeAsBase64PNG(altNode.originalNode);
-        addWarning(
-          "Groups with background images are not currently supported. Some images were exported as placeholder URLs",
-        );
-        imgUrl = getPlaceholderImage(node.width, node.height);
-        builder.addStyles(
-          formatWithJSX("background-image", settings.jsx, `url(${imgUrl})`),
-        );
+      }
+      // If it DOES have children
+      else {
+        if (nodeHasMultipleFills(node)) {
+          addWarning(
+            "Groups with multiple fills including background images are not currently supported. Either flatten the fills into a single fill, or move the fills into a separate element in your group.",
+          );
+          addPlaceholderImageToBuilder(builder, node, settings);
+        } else {
+          const imageData = await exportFillAsBase64PNG(altNode.originalNode);
+          if (imageData === null) {
+            addWarning("There was an error in processing some images");
+            addPlaceholderImageToBuilder(builder, node, settings);
+          } else {
+            const imgUrl = imageData.base64;
+            const { scaleMode } = imageData.fill;
+            const scalingFactor = imageData.fill.scalingFactor ?? 1;
+
+            if (scaleMode === "CROP") {
+              addWarning(
+                "Cropped background images are not currently supported. They will use 'cover' mode instead.",
+              );
+            }
+            if (scaleMode === "TILE") {
+              addWarning(
+                "Tiled background images are not fully supported. They may not appear at the correct scale or offset.",
+              );
+            }
+
+            builder.addStyles(
+              formatWithJSX(
+                "background-size",
+                settings.jsx,
+                scaleMode === "FILL" || scaleMode === "CROP"
+                  ? "cover"
+                  : scaleMode === "FIT" || scaleMode === "TILE"
+                    ? "contain"
+                    : `${scalingFactor * 100}%`,
+              ),
+              formatWithJSX(
+                "background-repeat",
+                settings.jsx,
+                scaleMode === "TILE" ? "repeat" : "no-repeat",
+              ),
+              scaleMode !== "TILE"
+                ? formatWithJSX("background-position", settings.jsx, "center")
+                : "",
+              formatWithJSX("background-image", settings.jsx, `url(${imgUrl})`),
+            );
+          }
+        }
       }
     }
 
@@ -285,6 +328,18 @@ const htmlContainer = async (
   }
 
   return children;
+};
+
+const addPlaceholderImageToBuilder = (
+  builder: HtmlDefaultBuilder,
+  node: SceneNode,
+  settings: HTMLSettings,
+) => {
+  addWarning("Some images were exported as placeholder URLs");
+  const imgUrl = getPlaceholderImage(node.width, node.height);
+  builder.addStyles(
+    formatWithJSX("background-image", settings.jsx, `url(${imgUrl})`),
+  );
 };
 
 const htmlSection = async (

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -240,7 +240,7 @@ const htmlContainer = async (
   // ignore the view when size is zero or less
   // while technically it shouldn't get less than 0, due to rounding errors,
   // it can get to values like: -0.000004196293048153166
-  if (node.width < 0 || node.height <= 0) {
+  if (node.width <= 0 || node.height <= 0) {
     return children;
   }
 
@@ -283,7 +283,6 @@ const htmlContainer = async (
       return `\n<${tag}${build}${src}></${tag}>`;
     }
   }
-
   return children;
 };
 

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -257,7 +257,16 @@ const htmlContainer = async (
       const hasChildren = "children" in node && node.children.length > 0;
       let imgUrl = "";
 
-      if (settings.embedImages) {
+      // TODO: This overrides the embedImages setting to only happen when HTML is selected but
+      // really this should be more of a global setting that isn't tied to a specific framework.
+      // It's being disabled in this way so the HTML preview will only embed images when it's HTML outuput.
+      // The reason this is so important is that it's a costly operation an it will slow down
+      // the generation of code for other languages and display different results in the preview
+      // than what the output will look like.
+      if (
+        settings.embedImages &&
+        (settings as PluginSettings).framework === "HTML"
+      ) {
         imgUrl = (await exportNodeAsBase64PNG(altNode, hasChildren)) ?? "";
       } else {
         addWarning("Some images were exported as placeholder URLs");

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -260,6 +260,7 @@ const htmlContainer = async (
         altNode.originalNode,
         hasChildren,
       );
+      altNode.base64 = imgUrl;
 
       if (hasChildren) {
         builder.addStyles(

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -1,15 +1,24 @@
 import { indentString } from "../common/indentString";
-import { retrieveTopFill } from "../common/retrieveFill";
 import { HtmlTextBuilder } from "./htmlTextBuilder";
 import { HtmlDefaultBuilder } from "./htmlDefaultBuilder";
 import { htmlAutoLayoutProps } from "./builderImpl/htmlAutoLayout";
 import { formatWithJSX } from "../common/parseJSX";
 import { commonSortChildrenWhenInferredAutoLayout } from "../common/commonChildrenOrder";
-import { addWarning } from "../common/commonConversionWarnings";
-import { PluginSettings, HTMLPreview, AltNode, HTMLSettings } from "types";
-import { renderAndAttachSVG } from "../altNodes/altNodeUtils";
+import {
+  PluginSettings,
+  HTMLPreview,
+  AltNode,
+  HTMLSettings,
+  ExportableNode,
+} from "types";
+import { isSVGNode, renderAndAttachSVG } from "../altNodes/altNodeUtils";
 import { getVisibleNodes } from "../common/nodeVisibility";
-import { getPlaceholderImage } from "../common/images";
+import {
+  exportNodeAsBase64PNG,
+  getPlaceholderImage,
+  nodeHasImageFill,
+} from "../common/images";
+import { addWarning } from "../common/commonConversionWarnings";
 
 const selfClosingTags = ["img"];
 
@@ -76,32 +85,35 @@ const htmlWidgetGenerator = async (
 };
 
 const convertNode = (settings: HTMLSettings) => async (node: SceneNode) => {
-  const altNode = await renderAndAttachSVG(node);
-  if (altNode.svg) return htmlWrapSVG(altNode, settings);
+  if (isSVGNode(node)) {
+    const altNode = await renderAndAttachSVG(node);
+    if (altNode.svg) return htmlWrapSVG(altNode, settings);
+  }
 
   switch (node.type) {
     case "RECTANGLE":
     case "ELLIPSE":
-      return htmlContainer(node, "", [], settings);
+      return await htmlContainer(node, "", [], settings);
     case "GROUP":
-      return htmlGroup(node, settings);
+      return await htmlGroup(node, settings);
     case "FRAME":
     case "COMPONENT":
     case "INSTANCE":
     case "COMPONENT_SET":
-      return htmlFrame(node, settings);
+      return await htmlFrame(node, settings);
     case "SECTION":
-      return htmlSection(node, settings);
+      return await htmlSection(node, settings);
     case "TEXT":
       return htmlText(node, settings);
     case "LINE":
       return htmlLine(node, settings);
     case "VECTOR":
-      addWarning("VectorNodes are not fully supported in HTML");
-      return htmlAsset(node, settings);
+      throw new Error(
+        "Normally vector type nodes are converted to SVG so this code point should be unreachable.",
+      );
     default:
+      return "";
   }
-  return "";
 };
 
 const htmlWrapSVG = (
@@ -195,7 +207,7 @@ const htmlFrame = async (
 
   if (node.layoutMode !== "NONE") {
     const rowColumn = htmlAutoLayoutProps(node, node, settings);
-    return htmlContainer(node, childrenStr, rowColumn, settings);
+    return await htmlContainer(node, childrenStr, rowColumn, settings);
   } else {
     if (settings.optimizeLayout && node.inferredAutoLayout !== null) {
       const rowColumn = htmlAutoLayoutProps(
@@ -203,39 +215,18 @@ const htmlFrame = async (
         node.inferredAutoLayout,
         settings,
       );
-      return htmlContainer(node, childrenStr, rowColumn, settings);
+      return await htmlContainer(node, childrenStr, rowColumn, settings);
     }
 
     // node.layoutMode === "NONE" && node.children.length > 1
     // children needs to be absolute
-    return htmlContainer(node, childrenStr, [], settings);
+    return await htmlContainer(node, childrenStr, [], settings);
   }
-};
-
-const htmlAsset = async (
-  node: SceneNode,
-  settings: HTMLSettings,
-): Promise<string> => {
-  if (!("opacity" in node) || !("layoutAlign" in node) || !("fills" in node)) {
-    return "";
-  }
-
-  const builder = new HtmlDefaultBuilder(node, settings)
-    .commonPositionStyles()
-    .commonShapeStyles();
-
-  if (retrieveTopFill(node.fills)?.type === "IMAGE") {
-    addWarning("Image fills are replaced with placeholders");
-    const imgUrl = getPlaceholderImage(node.width, node.height);
-    return `\n<img${builder.build()} src="${imgUrl}" />`;
-  }
-
-  return `\n<div${builder.build()}></div>`;
 };
 
 // properties named propSomething always take care of ","
 // sometimes a property might not exist, so it doesn't add ","
-const htmlContainer = (
+const htmlContainer = async (
   node: SceneNode &
     SceneNodeMixin &
     BlendMixin &
@@ -245,7 +236,7 @@ const htmlContainer = (
   children: string,
   additionalStyles: string[] = [],
   settings: HTMLSettings,
-): string => {
+): Promise<string> => {
   // ignore the view when size is zero or less
   // while technically it shouldn't get less than 0, due to rounding errors,
   // it can get to values like: -0.000004196293048153166
@@ -260,15 +251,24 @@ const htmlContainer = (
   if (builder.styles || additionalStyles) {
     let tag = "div";
     let src = "";
-    if (retrieveTopFill(node.fills)?.type === "IMAGE") {
-      addWarning("Image fills are replaced with placeholders");
-      const imageURL = getPlaceholderImage(node.width, node.height);
+
+    if (nodeHasImageFill(node)) {
+      let imgUrl: String;
+      const altNode = node as AltNode<ExportableNode>;
+
+      // if node has NO children
       if (!("children" in node) || node.children.length === 0) {
+        imgUrl = await exportNodeAsBase64PNG(altNode.originalNode);
         tag = "img";
-        src = ` src="${imageURL}"`;
+        src = ` src="${imgUrl}"`;
       } else {
+        // imgUrl = await exportNodeAsBase64PNG(altNode.originalNode);
+        addWarning(
+          "Groups with background images are not currently supported. Some images were exported as placeholder URLs",
+        );
+        imgUrl = getPlaceholderImage(node.width, node.height);
         builder.addStyles(
-          formatWithJSX("background-image", settings.jsx, `url(${imageURL})`),
+          formatWithJSX("background-image", settings.jsx, `url(${imgUrl})`),
         );
       }
     }

--- a/packages/backend/src/html/htmlMain.ts
+++ b/packages/backend/src/html/htmlMain.ts
@@ -255,12 +255,14 @@ const htmlContainer = async (
     if (nodeHasImageFill(node)) {
       const altNode = node as AltNode<ExportableNode>;
       const hasChildren = "children" in node && node.children.length > 0;
+      let imgUrl = "";
 
-      const imgUrl = await exportNodeAsBase64PNG(
-        altNode.originalNode,
-        hasChildren,
-      );
-      altNode.base64 = imgUrl;
+      if (settings.embedImages) {
+        imgUrl = (await exportNodeAsBase64PNG(altNode, hasChildren)) ?? "";
+      } else {
+        addWarning("Some images were exported as placeholder URLs");
+        imgUrl = getPlaceholderImage(node.width, node.height);
+      }
 
       if (hasChildren) {
         builder.addStyles(
@@ -284,18 +286,6 @@ const htmlContainer = async (
     }
   }
   return children;
-};
-
-const addPlaceholderImageToBuilder = (
-  builder: HtmlDefaultBuilder,
-  node: SceneNode,
-  settings: HTMLSettings,
-) => {
-  addWarning("Some images were exported as placeholder URLs");
-  const imgUrl = getPlaceholderImage(node.width, node.height);
-  builder.addStyles(
-    formatWithJSX("background-image", settings.jsx, `url(${imgUrl})`),
-  );
 };
 
 const htmlSection = async (

--- a/packages/plugin-ui/src/PluginUI.tsx
+++ b/packages/plugin-ui/src/PluginUI.tsx
@@ -25,7 +25,10 @@ type PluginUIProps = {
   selectedFramework: Framework;
   setSelectedFramework: (framework: Framework) => void;
   settings: PluginSettings | null;
-  onPreferenceChanged: (key: string, value: boolean | string) => void;
+  onPreferenceChanged: (
+    key: keyof PluginSettings,
+    value: boolean | string,
+  ) => void;
   colors: SolidColorConversion[];
   gradients: LinearGradientConversion[];
   isLoading: boolean;

--- a/packages/plugin-ui/src/codegenPreferenceOptions.ts
+++ b/packages/plugin-ui/src/codegenPreferenceOptions.ts
@@ -3,6 +3,14 @@ import { LocalCodegenPreferenceOptions, SelectPreferenceOptions } from "types";
 export const preferenceOptions: LocalCodegenPreferenceOptions[] = [
   {
     itemType: "individual_select",
+    propertyName: "embedImages",
+    label: "Embed Images",
+    description: "Convert images to Base64 and embed them in the code.",
+    isDefault: false,
+    includedLanguages: ["HTML"],
+  },
+  {
+    itemType: "individual_select",
     propertyName: "jsx",
     label: "React (JSX)",
     description: 'Render "class" attributes as "className"',

--- a/packages/plugin-ui/src/components/CodePanel.tsx
+++ b/packages/plugin-ui/src/components/CodePanel.tsx
@@ -16,7 +16,10 @@ interface CodePanelProps {
   settings: PluginSettings | null;
   preferenceOptions: LocalCodegenPreferenceOptions[];
   selectPreferenceOptions: SelectPreferenceOptions[];
-  onPreferenceChanged: (key: string, value: boolean | string) => void;
+  onPreferenceChanged: (
+    key: keyof PluginSettings,
+    value: boolean | string,
+  ) => void;
 }
 
 const CodePanel = (props: CodePanelProps) => {
@@ -34,20 +37,25 @@ const CodePanel = (props: CodePanelProps) => {
 
   // State for custom prefix for Tailwind classes.
   // It is initially set from settings (if available) or an empty string.
-  const [customPrefix, setCustomPrefix] = useState(settings?.customTailwindPrefix || "");
+  const [customPrefix, setCustomPrefix] = useState(
+    settings?.customTailwindPrefix || "",
+  );
 
   // Helper function to add the prefix before every class (or className) in the code.
   // It finds every occurrence of class="..." or className="..." and, for each class,
   // prepends the custom prefix.
   const applyPrefixToClasses = (codeString: string, prefix: string) => {
-    return codeString.replace(/(class(?:Name)?)="([^"]*)"/g, (match, attr, classes) => {
-      const prefixedClasses = classes
-        .split(/\s+/)
-        .filter(Boolean)
-        .map((cls: string) => prefix + cls)
-        .join(" ");
-      return `${attr}="${prefixedClasses}"`;
-    });
+    return codeString.replace(
+      /(class(?:Name)?)="([^"]*)"/g,
+      (match, attr, classes) => {
+        const prefixedClasses = classes
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((cls: string) => prefix + cls)
+          .join(" ");
+        return `${attr}="${prefixedClasses}"`;
+      },
+    );
   };
 
   // If the selected framework is Tailwind and a prefix is provided then transform the code.
@@ -131,7 +139,7 @@ const CodePanel = (props: CodePanelProps) => {
                 onChange={(e) => {
                   const newVal = e.target.value;
                   setCustomPrefix(newVal);
-                  onPreferenceChanged("tailwindPrefix", newVal);
+                  onPreferenceChanged("customTailwindPrefix", newVal);
                 }}
                 placeholder="e.g., tw-"
                 className="mt-1 p-1 px-2 border border-gray-300 rounded bg-neutral-100 dark:bg-neutral-700 text-sm"

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -72,6 +72,7 @@ export type AltNodeMetadata<T extends BaseNode> = {
   originalNode: T;
   canBeFlattened: boolean;
   svg?: string;
+  base64?: string;
 };
 export type AltNode<T extends BaseNode> = T & AltNodeMetadata<T>;
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -5,6 +5,7 @@ export interface HTMLSettings {
   jsx: boolean;
   optimizeLayout: boolean;
   showLayerNames: boolean;
+  embedImages: boolean;
 }
 export interface TailwindSettings extends HTMLSettings {
   roundTailwindValues: boolean;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -75,6 +75,8 @@ export type AltNodeMetadata<T extends BaseNode> = {
 };
 export type AltNode<T extends BaseNode> = T & AltNodeMetadata<T>;
 
+export type ExportableNode = SceneNode & ExportMixin & MinimalFillsMixin;
+
 // Styles & Conversions
 
 export type LayoutMode =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@figma/plugin-typings':
         specifier: ^1.105.0
         version: 1.105.0
+      js-base64:
+        specifier: ^3.7.7
+        version: 3.7.7
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2147,6 +2150,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4901,6 +4907,8 @@ snapshots:
   jiti@1.21.7: {}
 
   joycon@3.1.1: {}
+
+  js-base64@3.7.7: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
This PR adds an option to export images from Figma and embed them as base64-encoded PNGs in the source code (only for HTML). Not perfect but a big improvement in many situations.

This uses `exportAsync()` to flatten the fills into an image (which means multiple fills will be collapsed into one). 

Since this is a fairly costly operation, it's disabled by default and can be enabled in the HTML options. 

Rectangles with image fills are converted into <img/ > and groups/frames with image backgrounds will be <div> with background-image. Since exportAsync() also renders the children of a node, the children get hidden right before and visibility restored after - that causes a document change event so now i'm also making sure run() only gets called when there isn't already a conversion taking place. 

I think a nice future upgrade would be to add a box at the bottom similar to the color swatches that allows you to download the images discovered in the document as binary files (PNG). 