### PR TITLE
flutter: skip Column wrap if child is Column

### DIFF
--- a/packages/backend/src/flutter/flutterMain.ts
+++ b/packages/backend/src/flutter/flutterMain.ts
@@ -74,10 +74,14 @@ export const flutterMain = (
     case "snippet":
       return result;
     case "stateless":
-      result = generateWidgetCode("Column", { children: [result] });
+      if (!result.startsWith("Column")) {
+        result = generateWidgetCode("Column", { children: [result] });
+      }
       return getStatelessTemplate(stringToClassName(sceneNode[0].name), result);
     case "fullApp":
-      result = generateWidgetCode("Column", { children: [result] });
+      if (!result.startsWith("Column")) {
+        result = generateWidgetCode("Column", { children: [result] });
+      }
       return getFullAppTemplate(stringToClassName(sceneNode[0].name), result);
   }
 


### PR DESCRIPTION
Skip generating empty `Column` if child is already a `Column` 