### PR TITLE
fix: improve border handling for auto layout nodes in HTML and Tailwind output

### DIFF
--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -179,12 +179,14 @@ export class HtmlDefaultBuilder {
       }
       const weight = commonBorder.all;
 
+      // Check if the node has auto layout
+      const hasAutoLayout = "layoutMode" in node && node.layoutMode !== "NONE";
+
       if (
-        strokeAlign === "CENTER" ||
-        strokeAlign === "OUTSIDE" ||
-        node.type === "FRAME" ||
-        node.type === "INSTANCE" ||
-        node.type === "COMPONENT"
+        (strokeAlign === "CENTER" || strokeAlign === "OUTSIDE") || 
+        // Only use outline for frames/instances/components when they DON'T have auto layout
+        ((node.type === "FRAME" || node.type === "INSTANCE" || node.type === "COMPONENT") && 
+         !hasAutoLayout)
       ) {
         this.addStyles(
           formatWithJSX("outline", this.isJSX, consolidateBorders(weight)),
@@ -207,7 +209,7 @@ export class HtmlDefaultBuilder {
           );
         }
       } else {
-        // Default: use regular border on autolayout + strokeAlign: inside
+        // Use regular border when auto layout is present or for other node types with inside stroke
         this.addStyles(
           formatWithJSX("border", this.isJSX, consolidateBorders(weight)),
         );

--- a/packages/backend/src/tailwind/builderImpl/tailwindBorder.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindBorder.ts
@@ -78,14 +78,16 @@ export const tailwindBorderWidth = (
 
     const weight = commonBorder.all;
 
+    // Check if the node has auto layout
+    const hasAutoLayout = "layoutMode" in node && node.layoutMode !== "NONE";
+
     if (
-      strokeAlign === "CENTER" ||
-      strokeAlign === "OUTSIDE" ||
-      node.type === "FRAME" ||
-      node.type === "INSTANCE" ||
-      node.type === "COMPONENT"
+      (strokeAlign === "CENTER" || strokeAlign === "OUTSIDE") || 
+      // Only use outline for frames/instances/components when they DON'T have auto layout
+      ((node.type === "FRAME" || node.type === "INSTANCE" || node.type === "COMPONENT") && 
+       !hasAutoLayout)
     ) {
-      // For CENTER, OUTSIDE, or INSIDE+Frame, use outline
+      // For CENTER, OUTSIDE, or INSIDE+Frame without auto layout, use outline
       const property = getBorder(weight, "", true);
       let offsetProperty = "";
 
@@ -100,7 +102,7 @@ export const tailwindBorderWidth = (
         property: offsetProperty ? `${property} ${offsetProperty}` : property,
       };
     } else {
-      // Default case: use normal border (for INSIDE + AUTO_LAYOUT)
+      // Default case: use normal border (for INSIDE + AUTO_LAYOUT or other node types)
       return {
         isOutline: false,
         property: getBorder(weight, "", false),


### PR DESCRIPTION
### Description
This pull request resolves a bug in the HTML and Tailwind code generation logic for Figma nodes that use inside borders in combination with Auto Layout.

### 🐞 The Problem

When both of the following conditions were true:
	•	The Figma node had an inside border applied
	•	Auto Layout was enabled on the node

…the generated code incorrectly used the outline style instead of a proper border.

If Auto Layout was not enabled, the generator handled the border correctly using the border class in Tailwind and border style in HTML.

### ✅ The Fix

This PR updates the logic to ensure that when both an inside border and Auto Layout are present:
	•	The correct border style is applied
	•	outline is no longer incorrectly used

**The screenshots show the bug** (this PR fixes it):
<img width="1203" alt="Bildschirmfoto 2025-05-16 um 11 53 55" src="https://github.com/user-attachments/assets/34f9d07e-49f6-42f5-81bb-a64df3e77eb6" />

<img width="1209" alt="Bildschirmfoto 2025-05-16 um 11 54 36" src="https://github.com/user-attachments/assets/b37f09f9-986e-4cc8-996a-5a712c5bc920" />

<img width="1210" alt="Bildschirmfoto 2025-05-16 um 11 55 53" src="https://github.com/user-attachments/assets/0c1924b0-b66e-4c38-ae6b-b40a5d70dc48" />
