### PR TITLE
fix(backend): jsx compatible with html-entities & curly braces

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@figma/plugin-typings": "^1.121.0",
+    "html-entities": "^2.6.0",
     "js-base64": "^3.7.8",
     "nanoid": "^5.1.6",
     "react": "19.0.0",

--- a/packages/backend/src/common/parseJSX.ts
+++ b/packages/backend/src/common/parseJSX.ts
@@ -1,3 +1,4 @@
+import { encode } from "html-entities";
 import { numberToFixedString } from "./numToAutoFixed";
 
 export const formatWithJSX = (
@@ -40,3 +41,10 @@ export const formatMultipleJSX = (
     .filter(([key, value]) => value)
     .map(([key, value]) => formatWithJSX(key, isJsx, value!))
     .join(isJsx ? ", " : "; ");
+
+export const escapeJSXText = (text: string): string => {
+  return encode(text, { level: "html5" })
+    // process JSX curly braces
+    .replace(/\{/g, "&#123;")
+    .replace(/\}/g, "&#125;");
+};

--- a/packages/backend/src/html/htmlDefaultBuilder.ts
+++ b/packages/backend/src/html/htmlDefaultBuilder.ts
@@ -62,6 +62,11 @@ export class HtmlDefaultBuilder {
     return this.settings.htmlGenerationMode === "svelte";
   }
 
+  get needsJSXTextEscaping() {
+    const mode = this.settings.htmlGenerationMode;
+    return mode === "jsx" || mode === "styled-components" || mode === "svelte";
+  }
+
   get useStyledComponents() {
     return this.settings.htmlGenerationMode === "styled-components";
   }

--- a/packages/backend/src/html/htmlTextBuilder.ts
+++ b/packages/backend/src/html/htmlTextBuilder.ts
@@ -1,4 +1,4 @@
-import { formatMultipleJSX, formatWithJSX } from "../common/parseJSX";
+import { formatMultipleJSX, formatWithJSX, escapeJSXText } from "../common/parseJSX";
 import { HtmlDefaultBuilder } from "./htmlDefaultBuilder";
 import { htmlColorFromFills } from "./builderImpl/htmlColor";
 import {
@@ -70,7 +70,11 @@ export class HtmlTextBuilder extends HtmlDefaultBuilder {
         this.isJSX,
       );
 
-      const charsWithLineBreak = segment.characters.split("\n").join("<br/>");
+      let chars = segment.characters;
+      if (this.needsJSXTextEscaping) {
+        chars = escapeJSXText(chars);
+      }
+      const charsWithLineBreak = chars.split("\n").join("<br/>");
       const result: any = {
         style: styleAttributes,
         text: charsWithLineBreak,

--- a/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindDefaultBuilder.ts
@@ -54,6 +54,10 @@ export class TailwindDefaultBuilder {
     return this.settings.tailwindGenerationMode === "jsx";
   }
 
+  get needsJSXTextEscaping() {
+    return this.isJSX;
+  }
+
   get isTwigComponent() {
     return this.settings.tailwindGenerationMode === "twig" && this.node.type === "INSTANCE"
   }

--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -2,6 +2,7 @@ import {
   commonLetterSpacing,
   commonLineHeight,
 } from "../common/commonTextHeightSpacing";
+import { escapeJSXText } from "../common/parseJSX";
 import { tailwindColorFromFills } from "./builderImpl/tailwindColor";
 import {
   pxToFontSize,
@@ -60,7 +61,11 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
         .filter(Boolean)
         .join(" ");
 
-      const charsWithLineBreak = segment.characters.split("\n").join("<br/>");
+      let chars = segment.characters;
+      if (this.needsJSXTextEscaping) {
+        chars = escapeJSXText(chars);
+      }
+      const charsWithLineBreak = chars.split("\n").join("<br/>");
       return {
         style: styleClasses,
         text: charsWithLineBreak,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@figma/plugin-typings':
         specifier: ^1.121.0
         version: 1.121.0
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       js-base64:
         specifier: ^3.7.8
         version: 3.7.8
@@ -2278,6 +2281,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2664,6 +2670,7 @@ packages:
   next@15.5.7:
     resolution: {integrity: sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -5192,6 +5199,8 @@ snapshots:
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
+
+  html-entities@2.6.0: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## background

if figma text node includes content like `details: {serverlink}`, the output jsx may contain original `{serverlink}` and tsc throws error `cannot find name “serverlink”。ts(2304)`