### PR TITLE
fix: don't add opacity modifier for variable colors

### DIFF
--- a/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
+++ b/packages/backend/src/tailwind/builderImpl/tailwindColor.ts
@@ -81,7 +81,15 @@ export const tailwindSolidColor = (
   }
 
   // Original implementation for non-variable colors or when not using var syntax
-  const { colorName } = getColorInfo(fill);
+  const { colorName, colorType } = getColorInfo(fill);
+
+  // Don't add opacity modifier for variable colors - the alpha is already baked
+  // into the variable definition. Adding /50 to a variable that's already
+  // defined with alpha would incorrectly compound the opacity.
+  if (colorType === "variable") {
+    return `${kind}-${colorName}`;
+  }
+
   const effectiveOpacity = calculateEffectiveOpacity(fill);
   const opacity =
     effectiveOpacity !== 1.0 ? `/${nearestOpacity(effectiveOpacity)}` : "";
@@ -101,7 +109,14 @@ export const tailwindGradientStop = (
   stop: ColorStop,
   parentOpacity: number = 1.0,
 ): string => {
-  const { colorName } = getColorInfo(stop);
+  const { colorName, colorType } = getColorInfo(stop);
+
+  // Don't add opacity modifier for variable colors - the alpha is already baked
+  // into the variable definition
+  if (colorType === "variable") {
+    return colorName;
+  }
+
   const effectiveOpacity = calculateEffectiveOpacity(stop, parentOpacity);
   const opacity =
     effectiveOpacity !== 1.0 ? `/${nearestOpacity(effectiveOpacity)}` : "";


### PR DESCRIPTION
## Problem

When a color is from a Figma variable that already contains alpha (e.g., `rgba(255,0,0,0.5)`), the Tailwind output was incorrectly adding an opacity modifier.

**Expected:** `bg-myVar`
**Actual:** `bg-myVar/50`

This is incorrect because:
1. The variable already contains the alpha value
2. Adding `/50` compounds the opacity (50% of 50% = 25%)

## Solution

Skip the opacity modifier when `colorType` is `'variable'` since the alpha is already baked into the variable definition.

Changes made in `tailwindColor.ts`:
- `tailwindSolidColor()`: Return early for variable colors without opacity suffix
- `tailwindGradientStop()`: Same fix for gradient stops

## Testing

- [x] Build passes
- [x] No TypeScript errors

Fixes #232